### PR TITLE
chore: upgrade to Spring Boot 4.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
+# Perform the extraction in a separate builder container
 FROM eclipse-temurin:21-jre AS builder
 WORKDIR /builder
+# This points to the built jar file in the backend/target folder
 ARG JAR_FILE=backend/target/*.jar
+# Copy the jar file to the working directory and rename it to application.jar
 COPY ${JAR_FILE} application.jar
+# Extract the jar file using an efficient layout
 RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
 
+# This is the runtime container
 FROM eclipse-temurin:21-jre
 WORKDIR /application
+# Copy the extracted jar contents from the builder container into the working directory in the runtime container
+# Every copy step creates a new docker layer
+# This allows docker to only pull the changes it really needs
 COPY --from=builder /builder/extracted/dependencies/ ./
 COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
 COPY --from=builder /builder/extracted/application/ ./
+# Start the application jar - this is not the uber jar used by the builder
+# This jar only contains application code and references to the extracted jar files
+# This layout is efficient to start up and AOT cache (and CDS) friendly
 ENTRYPOINT ["java", "-jar", "application.jar"]

--- a/backend/.mvn/wrapper/maven-wrapper.properties
+++ b/backend/.mvn/wrapper/maven-wrapper.properties
@@ -1,19 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-wrapperVersion=3.3.2
+wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.7/apache-maven-3.9.7-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/backend/mvnw
+++ b/backend/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    https://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.2
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
@@ -105,14 +105,17 @@ trim() {
   printf "%s" "${1}" | tr -d '[:space:]'
 }
 
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
 maven-mvnd-*bin.*)
@@ -130,7 +133,7 @@ maven-mvnd-*bin.*)
   distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
 maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
-*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
@@ -227,7 +230,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
@@ -252,8 +255,41 @@ if command -v unzip >/dev/null; then
 else
   tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/backend/mvnw.cmd
+++ b/backend/mvnw.cmd
@@ -8,7 +8,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    https://www.apache.org/licenses/LICENSE-2.0
+@REM    http://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an
@@ -19,7 +19,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
 @REM
 @REM Optional ENV vars
 @REM   MVNW_REPOURL - repo url base for downloading maven distribution
@@ -40,7 +40,7 @@
 @SET __MVNW_ARG0_NAME__=
 @SET MVNW_USERNAME=
 @SET MVNW_PASSWORD=
-@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
 @echo Cannot start maven from wrapper >&2 && exit /b 1
 @GOTO :EOF
 : end batch / begin powershell #>
@@ -73,16 +73,30 @@ switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
 # apply MVNW_REPOURL and calculate MAVEN_HOME
 # maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
 if ($env:MVNW_REPOURL) {
-  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
-  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
 }
 $distributionUrlName = $distributionUrl -replace '^.*/',''
 $distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
-$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+
+$MAVEN_M2_PATH = "$HOME/.m2"
 if ($env:MAVEN_USER_HOME) {
-  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
 }
-$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
 $MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
 
 if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
@@ -134,7 +148,33 @@ if ($distributionSha256Sum) {
 
 # unzip and move
 Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
-Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
 try {
   Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
 } catch {

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>4.0.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>team.projectpulse</groupId>
@@ -28,18 +28,13 @@
     </scm>
     <properties>
         <java.version>21</java.version>
-        <spring-cloud-azure.version>6.0.0</spring-cloud-azure.version>
+        <spring-cloud-azure.version>7.0.0-beta.1</spring-cloud-azure.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
@@ -47,14 +42,13 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -70,32 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-testcontainers</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
-            <version>1.21.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.azure.spring</groupId>
-            <artifactId>spring-cloud-azure-starter-keyvault</artifactId>
+            <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -116,7 +85,53 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-aop</artifactId>
+            <artifactId>spring-boot-starter-aspectj</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.azure.spring</groupId>
+            <artifactId>spring-cloud-azure-starter-keyvault</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security-oauth2-resource-server-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mysql</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/backend/src/main/java/team/projectpulse/instructor/InstructorController.java
+++ b/backend/src/main/java/team/projectpulse/instructor/InstructorController.java
@@ -1,8 +1,10 @@
 package team.projectpulse.instructor;
 
 import team.projectpulse.instructor.converter.InstructorDtoToInstructorConverter;
+import team.projectpulse.instructor.converter.InstructorRegistrationRequestToInstructorConverter;
 import team.projectpulse.instructor.converter.InstructorToInstructorDtoConverter;
 import team.projectpulse.instructor.dto.InstructorDto;
+import team.projectpulse.instructor.dto.InstructorRegistrationRequest;
 import team.projectpulse.system.Result;
 import team.projectpulse.system.StatusCode;
 import jakarta.validation.Valid;
@@ -17,12 +19,14 @@ import java.util.Map;
 public class InstructorController {
 
     private final InstructorService instructorService;
+    private final InstructorRegistrationRequestToInstructorConverter registrationRequestToInstructorConverter;
     private final InstructorToInstructorDtoConverter instructorToInstructorDtoConverter;
     private final InstructorDtoToInstructorConverter instructorDtoToInstructorConverter;
 
 
-    public InstructorController(InstructorService instructorService, InstructorToInstructorDtoConverter instructorToInstructorDtoConverter, InstructorDtoToInstructorConverter instructorDtoToInstructorConverter) {
+    public InstructorController(InstructorService instructorService, InstructorRegistrationRequestToInstructorConverter registrationRequestToInstructorConverter, InstructorToInstructorDtoConverter instructorToInstructorDtoConverter, InstructorDtoToInstructorConverter instructorDtoToInstructorConverter) {
         this.instructorService = instructorService;
+        this.registrationRequestToInstructorConverter = registrationRequestToInstructorConverter;
         this.instructorToInstructorDtoConverter = instructorToInstructorDtoConverter;
         this.instructorDtoToInstructorConverter = instructorDtoToInstructorConverter;
     }
@@ -40,15 +44,10 @@ public class InstructorController {
         InstructorDto instructorDto = this.instructorToInstructorDtoConverter.convert(instructor);
         return new Result(true, StatusCode.SUCCESS, "Find instructor successfully", instructorDto);
     }
-
-    /**
-     * We are not using InstructorDto to receive the request params, but Instructor, since we require password.
-     *
-     * @param newInstructor
-     * @return
-     */
+    
     @PostMapping
-    public Result addInstructor(@RequestParam Integer courseId, @RequestParam Integer sectionId, @RequestParam String registrationToken, @RequestParam String role, @Valid @RequestBody Instructor newInstructor) {
+    public Result addInstructor(@RequestParam Integer courseId, @RequestParam Integer sectionId, @RequestParam String registrationToken, @RequestParam String role, @Valid @RequestBody InstructorRegistrationRequest registrationRequest) {
+        Instructor newInstructor = this.registrationRequestToInstructorConverter.convert(registrationRequest);
         Instructor savedInstructor = this.instructorService.saveInstructor(newInstructor, courseId, sectionId, registrationToken, role);
         InstructorDto savedInstructorDto = this.instructorToInstructorDtoConverter.convert(savedInstructor);
         return new Result(true, StatusCode.SUCCESS, "Add instructor successfully", savedInstructorDto);

--- a/backend/src/main/java/team/projectpulse/instructor/converter/InstructorRegistrationRequestToInstructorConverter.java
+++ b/backend/src/main/java/team/projectpulse/instructor/converter/InstructorRegistrationRequestToInstructorConverter.java
@@ -1,0 +1,22 @@
+package team.projectpulse.instructor.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import team.projectpulse.instructor.Instructor;
+import team.projectpulse.instructor.dto.InstructorRegistrationRequest;
+
+@Component
+public class InstructorRegistrationRequestToInstructorConverter implements Converter<InstructorRegistrationRequest, Instructor> {
+
+    @Override
+    public Instructor convert(InstructorRegistrationRequest source) {
+        Instructor instructor = new Instructor();
+        instructor.setUsername(source.username());
+        instructor.setFirstName(source.firstName());
+        instructor.setLastName(source.lastName());
+        instructor.setEmail(source.email());
+        instructor.setPassword(source.password());
+        return instructor;
+    }
+
+}

--- a/backend/src/main/java/team/projectpulse/instructor/dto/InstructorRegistrationRequest.java
+++ b/backend/src/main/java/team/projectpulse/instructor/dto/InstructorRegistrationRequest.java
@@ -1,0 +1,15 @@
+package team.projectpulse.instructor.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record InstructorRegistrationRequest(@NotEmpty(message = "Username must not be empty")
+                                            String username,
+                                            @NotEmpty(message = "First name must not be empty")
+                                            String firstName,
+                                            @NotEmpty(message = "Last name must not be empty")
+                                            String lastName,
+                                            @NotEmpty(message = "Email must not be empty")
+                                            String email,
+                                            @NotEmpty(message = "Password must not be empty")
+                                            String password) {
+}

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/ActivityMembershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/ActivityMembershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.activity.ActivitySecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class ActivityMembershipAuthorizationManager implements AuthorizationMana
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the activityId from the request URI: /activities/{activityId}
         Map<String, String> uriVariables = ACTIVITY_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer activityIdFromRequestUri = Integer.parseInt(uriVariables.get("activityId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/ActivityOwnershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/ActivityOwnershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.activity.ActivitySecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class ActivityOwnershipAuthorizationManager implements AuthorizationManag
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the activityId from the request URI: /activities/{activityId}
         Map<String, String> uriVariables = ACTIVITY_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer activityIdFromRequestUri = Integer.parseInt(uriVariables.get("activityId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignCriterionToRubricAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignCriterionToRubricAuthorizationManager.java
@@ -1,7 +1,9 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationResult;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.stereotype.Component;
@@ -23,7 +25,7 @@ public class AssignCriterionToRubricAuthorizationManager implements Authorizatio
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the rubricId and criterionId from the request URI: /rubrics/{rubricId}/criteria/{criterionId}
         Map<String, String> uriVariables = RUBRIC_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer rubricIdFromRequestUri = Integer.parseInt(uriVariables.get("rubricId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignInstructorToSectionAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignInstructorToSectionAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.section.SectionSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class AssignInstructorToSectionAuthorizationManager implements Authorizat
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the sectionId and instructorId from the request URI: /sections/{sectionId}/instructors/{instructorId}
         Map<String, String> uriVariables = SECTION_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer sectionIdFromRequestUri = Integer.parseInt(uriVariables.get("sectionId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignInstructorToTeamAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignInstructorToTeamAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.team.TeamSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class AssignInstructorToTeamAuthorizationManager implements Authorization
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the teamId and instructorId from the request URI: /teams/{teamId}/instructors/{instructorId}
         Map<String, String> uriVariables = TEAM_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer teamIdFromRequestUri = Integer.parseInt(uriVariables.get("teamId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignRubricToSectionAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignRubricToSectionAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.section.SectionSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class AssignRubricToSectionAuthorizationManager implements AuthorizationM
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the sectionId and rubricId from the request URI: /sections/{sectionId}/rubrics/{rubricId}
         Map<String, String> uriVariables = SECTION_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer sectionIdFromRequestUri = Integer.parseInt(uriVariables.get("sectionId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignStudentToTeamAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/AssignStudentToTeamAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.team.TeamSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class AssignStudentToTeamAuthorizationManager implements AuthorizationMan
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the teamId and studentId from the request URI: /teams/{teamId}/students/{studentId}
         Map<String, String> uriVariables = TEAM_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer teamIdFromRequestUri = Integer.parseInt(uriVariables.get("teamId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/CourseMembershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/CourseMembershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.course.CourseSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -20,9 +22,9 @@ public class CourseMembershipAuthorizationManager implements AuthorizationManage
     public CourseMembershipAuthorizationManager(CourseSecurityService courseSecurityService) {
         this.courseSecurityService = courseSecurityService;
     }
-    
+
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the courseId from the request URI: /courses/{courseId}
         Map<String, String> uriVariables = COURSE_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer courseIdFromRequestUri = Integer.parseInt(uriVariables.get("courseId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/CourseOwnershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/CourseOwnershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.course.CourseSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class CourseOwnershipAuthorizationManager implements AuthorizationManager
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the courseId from the request URI: /courses/{courseId}
         Map<String, String> uriVariables = COURSE_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer courseIdFromRequestUri = Integer.parseInt(uriVariables.get("courseId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/CriterionMembershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/CriterionMembershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.rubric.CriterionSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class CriterionMembershipAuthorizationManager implements AuthorizationMan
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the criterionId from the request URI: /criteria/{criterionId}
         Map<String, String> uriVariables = CRITERION_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer criterionIdFromRequestUri = Integer.parseInt(uriVariables.get("criterionId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/CriterionOwnershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/CriterionOwnershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.rubric.CriterionSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class CriterionOwnershipAuthorizationManager implements AuthorizationMana
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the criterionId from the request URI: /criteria/{criterionId}
         Map<String, String> uriVariables = CRITERION_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer criterionIdFromRequestUri = Integer.parseInt(uriVariables.get("criterionId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/EvaluationOwnershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/EvaluationOwnershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.evaluation.EvaluationSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class EvaluationOwnershipAuthorizationManager implements AuthorizationMan
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the evaluationId from the request URI: /evaluations/{evaluationId}
         Map<String, String> uriVariables = EVALUATION_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer evaluationIdFromRequestUri = Integer.parseInt(uriVariables.get("evaluationId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/RubricMembershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/RubricMembershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.rubric.RubricSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -26,7 +28,7 @@ public class RubricMembershipAuthorizationManager implements AuthorizationManage
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the rubricId from the request URI: /rubrics/{rubricId}
         Map<String, String> uriVariables = RUBRIC_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer rubricIdFromRequestUri = Integer.parseInt(uriVariables.get("rubricId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/RubricOwnershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/RubricOwnershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.rubric.RubricSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class RubricOwnershipAuthorizationManager implements AuthorizationManager
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the rubricId from the request URI: /rubrics/{rubricId}
         Map<String, String> uriVariables = RUBRIC_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer rubricIdFromRequestUri = Integer.parseInt(uriVariables.get("rubricId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/SectionInstructorAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/SectionInstructorAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.section.SectionSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -22,7 +24,7 @@ public class SectionInstructorAuthorizationManager implements AuthorizationManag
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the sectionId from the request URI: /sections/{sectionId}
         Map<String, String> uriVariables = SECTION_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer sectionIdFromRequestUri = Integer.parseInt(uriVariables.get("sectionId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/SectionMembershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/SectionMembershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.section.SectionSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -21,9 +23,9 @@ public class SectionMembershipAuthorizationManager implements AuthorizationManag
     public SectionMembershipAuthorizationManager(SectionSecurityService sectionSecurityService) {
         this.sectionSecurityService = sectionSecurityService;
     }
-    
+
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the sectionId from the request URI: /sections/{sectionId}
         Map<String, String> uriVariables = SECTION_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer sectionIdFromRequestUri = Integer.parseInt(uriVariables.get("sectionId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/SectionOwnershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/SectionOwnershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.section.SectionSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -22,7 +24,7 @@ public class SectionOwnershipAuthorizationManager implements AuthorizationManage
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the sectionId from the request URI: /sections/{sectionId}
         Map<String, String> uriVariables = SECTION_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer sectionIdFromRequestUri = Integer.parseInt(uriVariables.get("sectionId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/StudentInstructorAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/StudentInstructorAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.student.StudentSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -22,7 +24,7 @@ public class StudentInstructorAuthorizationManager implements AuthorizationManag
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the studentId from the request URI: /students/{studentId}
         Map<String, String> uriVariables = STUDENT_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer studentIdFromRequestUri = Integer.parseInt(uriVariables.get("studentId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/TeamMembershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/TeamMembershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.team.TeamSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class TeamMembershipAuthorizationManager implements AuthorizationManager<
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the teamId from the request URI: /teams/{teamId}
         Map<String, String> uriVariables = TEAM_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer teamIdFromRequestUri = Integer.parseInt(uriVariables.get("teamId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/TeamOwnershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/TeamOwnershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.team.TeamSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -23,7 +25,7 @@ public class TeamOwnershipAuthorizationManager implements AuthorizationManager<R
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the teamId from the request URI: /teams/{teamId}
         Map<String, String> uriVariables = TEAM_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer teamIdFromRequestUri = Integer.parseInt(uriVariables.get("teamId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/TransferTeamAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/TransferTeamAuthorizationManager.java
@@ -1,7 +1,9 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationResult;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.stereotype.Component;
@@ -22,7 +24,7 @@ public class TransferTeamAuthorizationManager implements AuthorizationManager<Re
     }
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         // Extract the teamId from the request URI: /teams/{teamId}/section
         Map<String, String> uriVariables = TEAM_URI_TEMPLATE.match(context.getRequest().getRequestURI());
         Integer teamIdFromRequestUri = Integer.parseInt(uriVariables.get("teamId"));

--- a/backend/src/main/java/team/projectpulse/security/authorizationmanagers/UserOwnershipAuthorizationManager.java
+++ b/backend/src/main/java/team/projectpulse/security/authorizationmanagers/UserOwnershipAuthorizationManager.java
@@ -1,5 +1,7 @@
 package team.projectpulse.security.authorizationmanagers;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
 import team.projectpulse.instructor.InstructorSecurityService;
 import team.projectpulse.student.StudentSecurityService;
 import org.springframework.security.authorization.AuthorizationDecision;
@@ -29,7 +31,7 @@ public class UserOwnershipAuthorizationManager implements AuthorizationManager<R
 
 
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authenticationSupplier, RequestAuthorizationContext context) {
+    public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, RequestAuthorizationContext context) {
         if (!STUDENT_USER_URI_TEMPLATE.match(context.getRequest().getRequestURI()).isEmpty()) {
             // Extract the studentId from the request URI: /students/{studentId}
             Map<String, String> uriVariables = STUDENT_USER_URI_TEMPLATE.match(context.getRequest().getRequestURI());

--- a/backend/src/main/java/team/projectpulse/student/StudentController.java
+++ b/backend/src/main/java/team/projectpulse/student/StudentController.java
@@ -1,8 +1,10 @@
 package team.projectpulse.student;
 
 import team.projectpulse.student.converter.StudentDtoToStudentConverter;
+import team.projectpulse.student.converter.StudentRegistrationToStudentConverter;
 import team.projectpulse.student.converter.StudentToStudentDtoConverter;
 import team.projectpulse.student.dto.StudentDto;
+import team.projectpulse.student.dto.StudentRegistrationRequest;
 import team.projectpulse.system.Result;
 import team.projectpulse.system.StatusCode;
 import jakarta.validation.Valid;
@@ -19,12 +21,14 @@ import java.util.stream.Collectors;
 public class StudentController {
 
     private final StudentService studentService;
+    private final StudentRegistrationToStudentConverter studentRegistrationToStudentConverter;
     private final StudentToStudentDtoConverter studentToStudentDtoConverter;
     private final StudentDtoToStudentConverter studentDtoToStudentConverter;
 
 
-    public StudentController(StudentService studentService, StudentToStudentDtoConverter studentToStudentDtoConverter, StudentDtoToStudentConverter studentDtoToStudentConverter) {
+    public StudentController(StudentService studentService, StudentRegistrationToStudentConverter studentRegistrationToStudentConverter, StudentToStudentDtoConverter studentToStudentDtoConverter, StudentDtoToStudentConverter studentDtoToStudentConverter) {
         this.studentService = studentService;
+        this.studentRegistrationToStudentConverter = studentRegistrationToStudentConverter;
         this.studentToStudentDtoConverter = studentToStudentDtoConverter;
         this.studentDtoToStudentConverter = studentDtoToStudentConverter;
     }
@@ -49,15 +53,10 @@ public class StudentController {
         List<StudentDto> studentDtos = students.stream().map(this.studentToStudentDtoConverter::convert).collect(Collectors.toList());
         return new Result(true, StatusCode.SUCCESS, "Find students by team id successfully", studentDtos);
     }
-
-    /**
-     * We are not using StudentDto to receive the request params, but Student, since we require password.
-     *
-     * @param newStudent
-     * @return
-     */
+    
     @PostMapping
-    public Result addStudent(@RequestParam Integer courseId, @RequestParam Integer sectionId, @RequestParam String registrationToken, @RequestParam String role, @Valid @RequestBody Student newStudent) {
+    public Result addStudent(@RequestParam Integer courseId, @RequestParam Integer sectionId, @RequestParam String registrationToken, @RequestParam String role, @Valid @RequestBody StudentRegistrationRequest registrationRequest) {
+        Student newStudent = this.studentRegistrationToStudentConverter.convert(registrationRequest);
         Student savedStudent = this.studentService.saveStudent(newStudent, courseId, sectionId, registrationToken, role);
         StudentDto savedStudentDto = this.studentToStudentDtoConverter.convert(savedStudent);
         return new Result(true, StatusCode.SUCCESS, "Add student successfully", savedStudentDto);

--- a/backend/src/main/java/team/projectpulse/student/converter/StudentRegistrationToStudentConverter.java
+++ b/backend/src/main/java/team/projectpulse/student/converter/StudentRegistrationToStudentConverter.java
@@ -1,0 +1,22 @@
+package team.projectpulse.student.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import team.projectpulse.student.Student;
+import team.projectpulse.student.dto.StudentRegistrationRequest;
+
+@Component
+public class StudentRegistrationToStudentConverter implements Converter<StudentRegistrationRequest, Student> {
+
+    @Override
+    public Student convert(StudentRegistrationRequest source) {
+        Student student = new Student();
+        student.setUsername(source.username());
+        student.setFirstName(source.firstName());
+        student.setLastName(source.lastName());
+        student.setEmail(source.email());
+        student.setPassword(source.password());
+        return student;
+    }
+    
+}

--- a/backend/src/main/java/team/projectpulse/student/dto/StudentRegistrationRequest.java
+++ b/backend/src/main/java/team/projectpulse/student/dto/StudentRegistrationRequest.java
@@ -1,0 +1,15 @@
+package team.projectpulse.student.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record StudentRegistrationRequest(@NotEmpty(message = "Username must not be empty")
+                                         String username,
+                                         @NotEmpty(message = "First name must not be empty")
+                                         String firstName,
+                                         @NotEmpty(message = "Last name must not be empty")
+                                         String lastName,
+                                         @NotEmpty(message = "Email must not be empty")
+                                         String email,
+                                         @NotEmpty(message = "Password must not be empty")
+                                         String password) {
+}

--- a/backend/src/main/java/team/projectpulse/system/exception/ExceptionHandlerAdvice.java
+++ b/backend/src/main/java/team/projectpulse/system/exception/ExceptionHandlerAdvice.java
@@ -1,8 +1,8 @@
 package team.projectpulse.system.exception;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 import team.projectpulse.system.Result;
 import team.projectpulse.system.StatusCode;
 import org.springframework.http.HttpStatus;
@@ -93,7 +93,7 @@ public class ExceptionHandlerAdvice {
     }
 
     @ExceptionHandler({HttpClientErrorException.class, HttpServerErrorException.class})
-    ResponseEntity<Result> handleRestClientException(HttpStatusCodeException ex) throws JsonProcessingException {
+    ResponseEntity<Result> handleRestClientException(HttpStatusCodeException ex) throws JacksonException {
         String exceptionMessage = ex.getMessage();
 
         // Replace <EOL> with actual newlines.
@@ -103,7 +103,7 @@ public class ExceptionHandlerAdvice {
         String jsonPart = exceptionMessage.substring(exceptionMessage.indexOf("{"), exceptionMessage.lastIndexOf("}") + 1);
 
         // Create an ObjectMapper instance.
-        ObjectMapper mapper = new ObjectMapper();
+        JsonMapper mapper = JsonMapper.builder().build();
 
         // Parse the JSON string to a JsonNode.
         JsonNode rootNode = mapper.readTree(jsonPart);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,9 +3,12 @@ spring:
     name: project-pulse
   profiles:
     active: dev # By default, the active profile is "dev". During production, it will be replaced to "prod" due to Azure's environment variables.
-#  web:
-#    resources:
-#      add-mappings: false
+  #  web:
+  #    resources:
+  #      add-mappings: false
+  devtools:
+    livereload:
+      enabled: true
 server:
   port: 80
 api:
@@ -20,7 +23,7 @@ management:
     health:
       show-details: always
       probes:
-        enabled: true
+        enabled: true # Since Spring Boot 4, liveness and readiness probes are enabled by default.
     env:
       show-values: always
     configprops:
@@ -39,7 +42,7 @@ management:
       enabled: true
   tracing:
     sampling:
-      probability: 1 # Only for demo purpose, change it back to 0.1 in production.
+      probability: 0.1 # Only for demo purpose, change it back to 0.1 in production.
 info:
   app:
     name: project-pulse

--- a/backend/src/test/java/team/projectpulse/activity/ActivityIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/activity/ActivityIntegrationTest.java
@@ -1,6 +1,6 @@
 package team.projectpulse.activity;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +48,7 @@ public class ActivityIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminBingyangToken; // Bingyang is the instructor of section 2
 
@@ -97,7 +98,7 @@ public class ActivityIntegrationTest {
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("teamId", "1");
         searchCriteria.put("week", "2023-W31");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -118,7 +119,7 @@ public class ActivityIntegrationTest {
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("teamId", "1");
         searchCriteria.put("week", "2023-W31");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -139,7 +140,7 @@ public class ActivityIntegrationTest {
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("teamId", "1");
         searchCriteria.put("week", "2023-W31");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -160,7 +161,7 @@ public class ActivityIntegrationTest {
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("teamId", "1");
         searchCriteria.put("week", "2023-W31");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -239,7 +240,7 @@ public class ActivityIntegrationTest {
         activityDto.put("actualHours", 7.5);
         activityDto.put("status", "COMPLETED");
 
-        String json = this.objectMapper.writeValueAsString(activityDto);
+        String json = this.jsonMapper.writeValueAsString(activityDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/activities").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
@@ -270,7 +271,7 @@ public class ActivityIntegrationTest {
         activityDto.put("actualHours", 10.5);
         activityDto.put("status", "COMPLETED");
 
-        String json = this.objectMapper.writeValueAsString(activityDto);
+        String json = this.jsonMapper.writeValueAsString(activityDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/activities/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
@@ -298,7 +299,7 @@ public class ActivityIntegrationTest {
         activityDto.put("actualHours", 10.5);
         activityDto.put("status", "COMPLETED");
 
-        String json = this.objectMapper.writeValueAsString(activityDto);
+        String json = this.jsonMapper.writeValueAsString(activityDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/activities/3").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
@@ -331,7 +332,7 @@ public class ActivityIntegrationTest {
         Map<String, Object> comment = new HashMap<>();
         comment.put("comment", "Good job! Keep up the good work!");
 
-        String json = this.objectMapper.writeValueAsString(comment);
+        String json = this.jsonMapper.writeValueAsString(comment);
 
         this.mockMvc.perform(patch(this.baseUrl + "/activities/3/comments").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -344,7 +345,7 @@ public class ActivityIntegrationTest {
         Map<String, Object> comment = new HashMap<>();
         comment.put("comment", "Good job! Keep up the good work!");
 
-        String json = this.objectMapper.writeValueAsString(comment);
+        String json = this.jsonMapper.writeValueAsString(comment);
 
         this.mockMvc.perform(patch(this.baseUrl + "/activities/3/comments").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJanaToken))
                 .andExpect(jsonPath("$.flag").value(false))

--- a/backend/src/test/java/team/projectpulse/course/CourseIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/course/CourseIntegrationTest.java
@@ -1,6 +1,6 @@
 package team.projectpulse.course;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.MySQLContainer;
 import team.projectpulse.system.StatusCode;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -31,7 +31,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
@@ -51,7 +50,7 @@ class CourseIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminBingyangToken; // Bingyang is the admin instructor of course 1 and 2.
 
@@ -102,7 +101,7 @@ class CourseIntegrationTest {
     void adminBingyangFindCoursesByCriteria() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -123,7 +122,7 @@ class CourseIntegrationTest {
     void instructorBillFindCoursesByCriteria() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -143,7 +142,7 @@ class CourseIntegrationTest {
     void adminTimFindCoursesByCriteria() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -192,7 +191,7 @@ class CourseIntegrationTest {
         Map<String, String> courseDto = new HashMap<>();
         courseDto.put("courseName", "New course");
         courseDto.put("courseDescription", "New course description");
-        String json = this.objectMapper.writeValueAsString(courseDto);
+        String json = this.jsonMapper.writeValueAsString(courseDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/courses").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -210,7 +209,7 @@ class CourseIntegrationTest {
         Map<String, String> courseDto = new HashMap<>();
         courseDto.put("courseName", "New course");
         courseDto.put("courseDescription", "New course description");
-        String json = this.objectMapper.writeValueAsString(courseDto);
+        String json = this.jsonMapper.writeValueAsString(courseDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/courses").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))
@@ -226,7 +225,7 @@ class CourseIntegrationTest {
         Map<String, String> courseDto = new HashMap<>();
         courseDto.put("courseName", "COSC 40993 Senior Design (Updated)");
         courseDto.put("courseDescription", "Senior design project course for Computer Science, Computer Information Technology, and Data Science majors");
-        String json = this.objectMapper.writeValueAsString(courseDto);
+        String json = this.jsonMapper.writeValueAsString(courseDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/courses/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -243,7 +242,7 @@ class CourseIntegrationTest {
         Map<String, String> courseDto = new HashMap<>();
         courseDto.put("courseName", "COSC 40993 Senior Design (Updated)");
         courseDto.put("courseDescription", "Senior design project course for Computer Science, Computer Information Technology, and Data Science majors");
-        String json = this.objectMapper.writeValueAsString(courseDto);
+        String json = this.jsonMapper.writeValueAsString(courseDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/courses/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminTimToken))
@@ -258,7 +257,7 @@ class CourseIntegrationTest {
         Map<String, String> courseDto = new HashMap<>();
         courseDto.put("courseName", "COSC 40993 Senior Design (Updated)");
         courseDto.put("courseDescription", "Senior design project course for Computer Science, Computer Information Technology, and Data Science majors");
-        String json = this.objectMapper.writeValueAsString(courseDto);
+        String json = this.jsonMapper.writeValueAsString(courseDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/courses/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminTimToken))

--- a/backend/src/test/java/team/projectpulse/evaluation/EvaluationIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/evaluation/EvaluationIntegrationTest.java
@@ -1,6 +1,6 @@
 package team.projectpulse.evaluation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.testcontainers.containers.MySQLContainer;
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -63,7 +63,7 @@ public class EvaluationIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminBingyangToken;
 
@@ -118,7 +118,7 @@ public class EvaluationIntegrationTest {
         given(this.clock.getZone()).willReturn(fixedClock.getZone());
 
         PeerEvaluationDto peerEvaluationDto = new PeerEvaluationDto(null, "2023-W36", 4, "John Smith", 5, "Eric Hudson", ratingDtos, 41.0, "Good job", "Keep it up", null, null);
-        String json = this.objectMapper.writeValueAsString(peerEvaluationDto);
+        String json = this.jsonMapper.writeValueAsString(peerEvaluationDto);
 
         this.mockMvc.perform(post(this.baseUrl + "/evaluations").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -157,7 +157,7 @@ public class EvaluationIntegrationTest {
 
         // Active weeks are "2023-W31", "2023-W32", "2023-W33", "2023-W34", "2023-W35", "2023-W36", "2023-W37", "2023-W38", "2023-W39", "2023-W40"
         PeerEvaluationDto peerEvaluationDto = new PeerEvaluationDto(null, "2023-W19", 3, "John Smith", 6, "Woody Moon", ratingDtos, 41.0, "Good job", "Keep it up", null, null);
-        String json = this.objectMapper.writeValueAsString(peerEvaluationDto);
+        String json = this.jsonMapper.writeValueAsString(peerEvaluationDto);
 
         this.mockMvc.perform(post(this.baseUrl + "/evaluations").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(false))
@@ -182,7 +182,7 @@ public class EvaluationIntegrationTest {
         given(this.clock.getZone()).willReturn(fixedClock.getZone());
 
         PeerEvaluationDto peerEvaluationDto = new PeerEvaluationDto(null, "2023-W33", 3, "John Smith", 6, "Woody Moon", ratingDtos, 41.0, "Good job", "Keep it up", null, null);
-        String json = this.objectMapper.writeValueAsString(peerEvaluationDto);
+        String json = this.jsonMapper.writeValueAsString(peerEvaluationDto);
 
         this.mockMvc.perform(post(this.baseUrl + "/evaluations").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(false))
@@ -207,7 +207,7 @@ public class EvaluationIntegrationTest {
         given(this.clock.getZone()).willReturn(fixedClock.getZone());
 
         PeerEvaluationDto peerEvaluationDto = new PeerEvaluationDto(null, "2023-W31", 4, "John Smith", 7, "Woody Moon", ratingDtos, 41.0, "Good job", "Keep it up", null, null);
-        String json = this.objectMapper.writeValueAsString(peerEvaluationDto);
+        String json = this.jsonMapper.writeValueAsString(peerEvaluationDto);
 
         this.mockMvc.perform(post(this.baseUrl + "/evaluations").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(false))
@@ -232,7 +232,7 @@ public class EvaluationIntegrationTest {
         given(this.clock.getZone()).willReturn(fixedClock.getZone());
 
         PeerEvaluationDto peerEvaluationDto = new PeerEvaluationDto(null, "2023-W31", 4, "John Smith", 5, "Eric Hudson", ratingDtos, 41.0, "Good job", "Keep it up", null, null);
-        String json = this.objectMapper.writeValueAsString(peerEvaluationDto);
+        String json = this.jsonMapper.writeValueAsString(peerEvaluationDto);
 
         this.mockMvc.perform(post(this.baseUrl + "/evaluations").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(false))
@@ -276,7 +276,7 @@ public class EvaluationIntegrationTest {
                 new RatingDto(6, 6, 6.0)
         );
         PeerEvaluationDto peerEvaluationDto = new PeerEvaluationDto(1, "2023-W31", 4, "John Smith", 5, "Eric Hudson", ratingDtos, 41.0, "Good job", "Keep it up", null, null);
-        String json = this.objectMapper.writeValueAsString(peerEvaluationDto);
+        String json = this.jsonMapper.writeValueAsString(peerEvaluationDto);
 
         this.mockMvc.perform(put(this.baseUrl + "/evaluations/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -303,7 +303,7 @@ public class EvaluationIntegrationTest {
                 new RatingDto(6, 6, 6.0)
         );
         PeerEvaluationDto peerEvaluationDto = new PeerEvaluationDto(5, "2023-W31", 4, "John Smith", 5, "Eric Hudson", ratingDtos, 41.0, "Good job", "Keep it up", null, null);
-        String json = this.objectMapper.writeValueAsString(peerEvaluationDto);
+        String json = this.jsonMapper.writeValueAsString(peerEvaluationDto);
 
         this.mockMvc.perform(put(this.baseUrl + "/evaluations/5").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(false))

--- a/backend/src/test/java/team/projectpulse/instructor/InstructorIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/instructor/InstructorIntegrationTest.java
@@ -1,6 +1,6 @@
 package team.projectpulse.instructor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.MySQLContainer;
 import team.projectpulse.system.StatusCode;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -47,7 +47,7 @@ class InstructorIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminBingyangToken;
 
@@ -89,7 +89,7 @@ class InstructorIntegrationTest {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("firstName", "Bill");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -149,7 +149,7 @@ class InstructorIntegrationTest {
         instructorDto.put("email", "e.musk@abc.edu");
         instructorDto.put("password", "Abc123456");
 
-        String json = this.objectMapper.writeValueAsString(instructorDto);
+        String json = this.jsonMapper.writeValueAsString(instructorDto);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
@@ -179,7 +179,7 @@ class InstructorIntegrationTest {
         instructorDto.put("email", "j.huang@abc.edu");
         instructorDto.put("password", "123456");
 
-        String json = this.objectMapper.writeValueAsString(instructorDto);
+        String json = this.jsonMapper.writeValueAsString(instructorDto);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
@@ -203,7 +203,7 @@ class InstructorIntegrationTest {
         instructorDto.put("email", "e.musk@abc.edu");
         instructorDto.put("password", "Abc123456");
 
-        String json = this.objectMapper.writeValueAsString(instructorDto);
+        String json = this.jsonMapper.writeValueAsString(instructorDto);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
@@ -227,7 +227,7 @@ class InstructorIntegrationTest {
         instructorDto.put("email", "l.santos@abc.edu");
         instructorDto.put("password", "Abc123456");
 
-        String json = this.objectMapper.writeValueAsString(instructorDto);
+        String json = this.jsonMapper.writeValueAsString(instructorDto);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
@@ -253,7 +253,7 @@ class InstructorIntegrationTest {
         instructorDto.put("enabled", true); // Instructor can't change their own enabled status.
         instructorDto.put("roles", "admin"); // Instructor can't change their own role.
 
-        String json = this.objectMapper.writeValueAsString(instructorDto);
+        String json = this.jsonMapper.writeValueAsString(instructorDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/instructors/2").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -281,7 +281,7 @@ class InstructorIntegrationTest {
         instructorDto.put("enabled", false); // Instructor can't change their own enabled status.
         instructorDto.put("roles", "admin"); // Instructor can't change their own role.
 
-        String json = this.objectMapper.writeValueAsString(instructorDto);
+        String json = this.jsonMapper.writeValueAsString(instructorDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/instructors/2").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))
@@ -306,7 +306,7 @@ class InstructorIntegrationTest {
         instructorDto.put("lastName", "Wei");
         instructorDto.put("email", "b.wei@abc.edu");
 
-        String json = this.objectMapper.writeValueAsString(instructorDto);
+        String json = this.jsonMapper.writeValueAsString(instructorDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/instructors/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))

--- a/backend/src/test/java/team/projectpulse/rubric/CriterionIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/rubric/CriterionIntegrationTest.java
@@ -1,6 +1,6 @@
 package team.projectpulse.rubric;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -47,7 +47,7 @@ class CriterionIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminBingyangToken;
 
@@ -81,7 +81,7 @@ class CriterionIntegrationTest {
     void adminBingyangFindPeerEvaluationCriteriaByCriteriaInCourse1() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -100,7 +100,7 @@ class CriterionIntegrationTest {
     void adminTimFindPeerEvaluationCriteriaByCriteriaInCourse1() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -144,7 +144,7 @@ class CriterionIntegrationTest {
         criterionDto.put("description", "Description of the criterion. (1-10)");
         criterionDto.put("maxScore", "10");
 
-        String json = this.objectMapper.writeValueAsString(criterionDto);
+        String json = this.jsonMapper.writeValueAsString(criterionDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/criteria").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -166,7 +166,7 @@ class CriterionIntegrationTest {
         criterionDto.put("criterion", "Quality of work (updated)");
         criterionDto.put("description", "How do you rate the quality of this teammate's work? (1-10)");
         criterionDto.put("maxScore", "10");
-        String json = this.objectMapper.writeValueAsString(criterionDto);
+        String json = this.jsonMapper.writeValueAsString(criterionDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/criteria/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -188,7 +188,7 @@ class CriterionIntegrationTest {
         criterionDto.put("criterion", "Quality of work (updated)");
         criterionDto.put("description", "How do you rate the quality of this teammate's work? (1-10)");
         criterionDto.put("maxScore", "10");
-        String json = this.objectMapper.writeValueAsString(criterionDto);
+        String json = this.jsonMapper.writeValueAsString(criterionDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/criteria/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminTimToken))

--- a/backend/src/test/java/team/projectpulse/rubric/RubricIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/rubric/RubricIntegrationTest.java
@@ -1,6 +1,6 @@
 package team.projectpulse.rubric;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -47,7 +47,7 @@ class RubricIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminBingyangToken;
 
@@ -97,7 +97,7 @@ class RubricIntegrationTest {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("rubricName", "rubric");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -117,7 +117,7 @@ class RubricIntegrationTest {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("rubricName", "rubric");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -177,7 +177,7 @@ class RubricIntegrationTest {
         Map<String, String> rubricDto = new HashMap<>();
         rubricDto.put("rubricName", "Peer Eval Rubric v2");
 
-        String json = this.objectMapper.writeValueAsString(rubricDto);
+        String json = this.jsonMapper.writeValueAsString(rubricDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/rubrics").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -196,7 +196,7 @@ class RubricIntegrationTest {
         Map<String, String> rubricDto = new HashMap<>();
         rubricDto.put("rubricName", "Peer Eval Rubric v1 (update)");
 
-        String json = this.objectMapper.writeValueAsString(rubricDto);
+        String json = this.jsonMapper.writeValueAsString(rubricDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/rubrics/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -215,7 +215,7 @@ class RubricIntegrationTest {
         Map<String, String> rubricDto = new HashMap<>();
         rubricDto.put("rubricName", "Peer Eval Rubric v1 (update)");
 
-        String json = this.objectMapper.writeValueAsString(rubricDto);
+        String json = this.jsonMapper.writeValueAsString(rubricDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/rubrics/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminTimToken))

--- a/backend/src/test/java/team/projectpulse/section/SectionIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/section/SectionIntegrationTest.java
@@ -1,6 +1,6 @@
 package team.projectpulse.section;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.MySQLContainer;
 import team.projectpulse.system.StatusCode;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -51,7 +51,7 @@ class SectionIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminBingyangToken;
 
@@ -111,7 +111,7 @@ class SectionIntegrationTest {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("sectionName", "2023");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -131,7 +131,7 @@ class SectionIntegrationTest {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("isActive", "true");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -150,7 +150,7 @@ class SectionIntegrationTest {
     void instructorBillFindSectionsByCriteria() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/sections/search").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))
@@ -164,7 +164,7 @@ class SectionIntegrationTest {
     void adminTimFindSectionsByCriteria() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -258,7 +258,7 @@ class SectionIntegrationTest {
         sectionDto.put("peerEvaluationWeeklyDueDay", "TUESDAY");
         sectionDto.put("peerEvaluationDueTime", "15:00");
 
-        String json = this.objectMapper.writeValueAsString(sectionDto);
+        String json = this.jsonMapper.writeValueAsString(sectionDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/sections").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -277,7 +277,7 @@ class SectionIntegrationTest {
                 .andExpect(jsonPath("$.data.peerEvaluationDueTime").value("15:00"));
 
         Map<String, String> searchCriteria = new HashMap<>();
-        json = this.objectMapper.writeValueAsString(searchCriteria);
+        json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         this.mockMvc.perform(post(this.baseUrl + "/sections/search").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -300,7 +300,7 @@ class SectionIntegrationTest {
         sectionDto.put("peerEvaluationWeeklyDueDay", "TUESDAY");
         sectionDto.put("peerEvaluationDueTime", "15:00");
 
-        String json = this.objectMapper.writeValueAsString(sectionDto);
+        String json = this.jsonMapper.writeValueAsString(sectionDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/sections").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))
@@ -323,7 +323,7 @@ class SectionIntegrationTest {
         sectionDto.put("peerEvaluationWeeklyDueDay", "TUESDAY");
         sectionDto.put("peerEvaluationDueTime", "15:00"); // Updated peerEvaluationDueTime
 
-        String json = this.objectMapper.writeValueAsString(sectionDto);
+        String json = this.jsonMapper.writeValueAsString(sectionDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/sections/2").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -350,7 +350,7 @@ class SectionIntegrationTest {
         sectionDto.put("startDate", "08-16-2023");
         sectionDto.put("endDate", "04-30-2024");
 
-        String json = this.objectMapper.writeValueAsString(sectionDto);
+        String json = this.jsonMapper.writeValueAsString(sectionDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/sections/2").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminTimToken))
@@ -367,7 +367,7 @@ class SectionIntegrationTest {
     void adminBingyangSetUpActiveWeeks() throws Exception {
         // Given
         List<String> activeWeeks = List.of("2023-W31", "2023-W32", "2023-W33", "2023-W34", "2023-W35");
-        String json = this.objectMapper.writeValueAsString(activeWeeks);
+        String json = this.jsonMapper.writeValueAsString(activeWeeks);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/sections/2/weeks").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -380,7 +380,7 @@ class SectionIntegrationTest {
     void instructorBillSetUpActiveWeeks() throws Exception {
         // Given
         List<String> activeWeeks = List.of("2023-W31", "2023-W32", "2023-W33", "2023-W34", "2023-W35");
-        String json = this.objectMapper.writeValueAsString(activeWeeks);
+        String json = this.jsonMapper.writeValueAsString(activeWeeks);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/sections/2/weeks").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))
@@ -393,7 +393,7 @@ class SectionIntegrationTest {
     void adminTimSetUpActiveWeeks() throws Exception {
         // Given
         List<String> activeWeeks = List.of("2023-W31", "2023-W32", "2023-W33", "2023-W34", "2023-W35");
-        String json = this.objectMapper.writeValueAsString(activeWeeks);
+        String json = this.jsonMapper.writeValueAsString(activeWeeks);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/sections/2/weeks").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminTimToken))
@@ -475,7 +475,7 @@ class SectionIntegrationTest {
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
 
-        String json = this.objectMapper.writeValueAsString(emails);
+        String json = this.jsonMapper.writeValueAsString(emails);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/sections/2/students/email-invitations").contentType(MediaType.APPLICATION_JSON).content(json).params(requestParams).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -493,7 +493,7 @@ class SectionIntegrationTest {
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
 
-        String json = this.objectMapper.writeValueAsString(emails);
+        String json = this.jsonMapper.writeValueAsString(emails);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/sections/2/students/email-invitations").contentType(MediaType.APPLICATION_JSON).content(json).params(requestParams).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminTimToken))

--- a/backend/src/test/java/team/projectpulse/student/StudentIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/student/StudentIntegrationTest.java
@@ -1,7 +1,8 @@
 package team.projectpulse.student;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -48,7 +48,7 @@ class StudentIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminToken;
 
@@ -106,7 +106,7 @@ class StudentIntegrationTest {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
         searchCriteria.put("teamName", "Team1");
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -175,7 +175,7 @@ class StudentIntegrationTest {
         studentDto.put("email", "l.santos@abc.edu");
         studentDto.put("password", "Abc123456");
 
-        String json = this.objectMapper.writeValueAsString(studentDto);
+        String json = this.jsonMapper.writeValueAsString(studentDto);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
@@ -205,7 +205,7 @@ class StudentIntegrationTest {
         studentDto.put("email", "m.grant@abc.edu");
         studentDto.put("password", "123456");
 
-        String json = this.objectMapper.writeValueAsString(studentDto);
+        String json = this.jsonMapper.writeValueAsString(studentDto);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
@@ -229,7 +229,7 @@ class StudentIntegrationTest {
         studentDto.put("email", "l.santos@abc.edu");
         studentDto.put("password", "123456");
 
-        String json = this.objectMapper.writeValueAsString(studentDto);
+        String json = this.jsonMapper.writeValueAsString(studentDto);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("courseId", "1");
@@ -255,7 +255,7 @@ class StudentIntegrationTest {
         studentDto.put("enabled", false); // Student cannot change their enabled status.
         studentDto.put("roles", "instructor"); // Student cannot change their role.
 
-        String json = this.objectMapper.writeValueAsString(studentDto);
+        String json = this.jsonMapper.writeValueAsString(studentDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/students/4").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
@@ -280,7 +280,7 @@ class StudentIntegrationTest {
         studentDto.put("lastName", "Hudson");
         studentDto.put("email", "e.hudson@abc.edu");
 
-        String json = this.objectMapper.writeValueAsString(studentDto);
+        String json = this.jsonMapper.writeValueAsString(studentDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/students/5").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))

--- a/backend/src/test/java/team/projectpulse/team/TeamIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/team/TeamIntegrationTest.java
@@ -1,6 +1,6 @@
 package team.projectpulse.team;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -47,7 +47,7 @@ class TeamIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     String adminBingyangToken;
 
@@ -96,7 +96,7 @@ class TeamIntegrationTest {
     void adminBingyangFindTeamsByCriteria() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -115,7 +115,7 @@ class TeamIntegrationTest {
     void adminTimFindTeamsByCriteria() throws Exception {
         // Given
         Map<String, String> searchCriteria = new HashMap<>();
-        String json = this.objectMapper.writeValueAsString(searchCriteria);
+        String json = this.jsonMapper.writeValueAsString(searchCriteria);
 
         MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
         requestParams.add("page", "0");
@@ -192,7 +192,7 @@ class TeamIntegrationTest {
         teamDto.put("teamWebsiteUrl", "https://www.team4.com");
         teamDto.put("sectionId", 2);
 
-        String json = this.objectMapper.writeValueAsString(teamDto);
+        String json = this.jsonMapper.writeValueAsString(teamDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/teams").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -215,7 +215,7 @@ class TeamIntegrationTest {
         teamDto.put("teamWebsiteUrl", "https://www.team4.com");
         teamDto.put("sectionId", 2);
 
-        String json = this.objectMapper.writeValueAsString(teamDto);
+        String json = this.jsonMapper.writeValueAsString(teamDto);
 
         // When and then
         this.mockMvc.perform(post(this.baseUrl + "/teams").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))
@@ -234,7 +234,7 @@ class TeamIntegrationTest {
         teamDto.put("teamWebsiteUrl", "https://www.team1.com");
         teamDto.put("sectionId", 2);
 
-        String json = this.objectMapper.writeValueAsString(teamDto);
+        String json = this.jsonMapper.writeValueAsString(teamDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/teams/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -257,7 +257,7 @@ class TeamIntegrationTest {
         teamDto.put("teamWebsiteUrl", "https://www.team1.com");
         teamDto.put("sectionId", 2);
 
-        String json = this.objectMapper.writeValueAsString(teamDto);
+        String json = this.jsonMapper.writeValueAsString(teamDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/teams/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))
@@ -275,7 +275,7 @@ class TeamIntegrationTest {
         teamDto.put("teamWebsiteUrl", "https://www.team1.com");
         teamDto.put("sectionId", 2);
 
-        String json = this.objectMapper.writeValueAsString(teamDto);
+        String json = this.jsonMapper.writeValueAsString(teamDto);
 
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/teams/1").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminTimToken))
@@ -338,7 +338,7 @@ class TeamIntegrationTest {
         Map<String, Object> transferTeamRequest = new HashMap<>();
         transferTeamRequest.put("sectionId", "1");
 
-        String json = this.objectMapper.writeValueAsString(transferTeamRequest);
+        String json = this.jsonMapper.writeValueAsString(transferTeamRequest);
 
         this.mockMvc.perform(patch(this.baseUrl + "/teams/1/section").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -364,7 +364,7 @@ class TeamIntegrationTest {
         Map<String, Object> transferTeamRequest = new HashMap<>();
         transferTeamRequest.put("sectionId", "3"); // Section 3 belongs to a different course
 
-        String json = this.objectMapper.writeValueAsString(transferTeamRequest);
+        String json = this.jsonMapper.writeValueAsString(transferTeamRequest);
 
         this.mockMvc.perform(patch(this.baseUrl + "/teams/1/section").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(false))
@@ -378,7 +378,7 @@ class TeamIntegrationTest {
         Map<String, Object> transferTeamRequest = new HashMap<>();
         transferTeamRequest.put("sectionId", "1"); // Section 3 belongs to a different course
 
-        String json = this.objectMapper.writeValueAsString(transferTeamRequest);
+        String json = this.jsonMapper.writeValueAsString(transferTeamRequest);
 
         // Let Bill, who is not a course admin, try to transfer the team
         this.mockMvc.perform(patch(this.baseUrl + "/teams/1/section").contentType(MediaType.APPLICATION_JSON).content(json).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))

--- a/backend/src/test/java/team/projectpulse/user/UserIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/user/UserIntegrationTest.java
@@ -1,12 +1,12 @@
 package team.projectpulse.user;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
@@ -33,7 +33,7 @@ class UserIntegrationTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    JsonMapper jsonMapper;
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;


### PR DESCRIPTION
## 🚀 Major Upgrade: Spring Boot 4.0.2

### Summary
This PR upgrades the backend project from **Spring Boot 3.5.8 → Spring Boot 4.0.2**.  
[Spring Boot 4](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes) introduces significant architectural, dependency, and API changes, including a new modular starter design, **Jackson 3**, and security API updates. This PR adapts the codebase accordingly and resolves all resulting compilation, runtime, and test issues.

---

## 🔧 Key Changes

### 1. Maven Dependencies & Starter Modularization
Spring Boot 4 adopts a more granular modular design, replacing several large starters with smaller, focused ones. As a result, multiple dependency updates were required in `pom.xml`.

#### Starter / Artifact Renames
- `spring-boot-starter-web` → `spring-boot-starter-webmvc`
- `spring-boot-starter-oauth2-resource-server` → `spring-boot-starter-security-oauth2-resource-server`
- `spring-boot-starter-aop` → `spring-boot-starter-aspectj`
- Test starters are now split into domain-specific artifacts:
  - `spring-boot-starter-test` →
    - `spring-boot-starter-webmvc-test`
    - `spring-boot-starter-data-jpa-test`
    - `spring-boot-starter-security-oauth2-resource-server-test`
    - `spring-boot-starter-actuator-test`

#### Testcontainers Artifact Changes
- `org.testcontainers:junit-jupiter` → `org.testcontainers:testcontainers-junit-jupiter`
- `org.testcontainers:mysql` → `org.testcontainers:testcontainers-mysql`

These changes are required to align with Spring Boot 4’s dependency model and avoid missing transitive dependencies.

---

### 2. Integration Test Imports (WebMVC)
Spring Boot 4 moved several test annotations into WebMVC-specific packages.

    // Old
    org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc

    // New
    org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc

This change was applied across all affected integration test classes.

---

### 3. Jackson 3 Migration (Major Change)
Spring Boot 4 uses **Jackson 3** by default.

#### Package & API Changes
- Jackson components now live under `tools.jackson.*` instead of `com.fasterxml.*` except for jackson-annotations which remains unchanged for backward-compatibility reasons.
- `ObjectMapper` (mutable) → `JsonMapper` (immutable)

All relevant classes were updated to use `JsonMapper`.

#### Behavior Change: Primitive Null Handling
Jackson 3 defaults:

    FAIL_ON_NULL_FOR_PRIMITIVES = true

DTOs with primitive fields (e.g., `boolean enabled`) will fail deserialization if the field is omitted in the request body.

##### Impact
This affected user-creation workflows (Instructor / Student registration).

##### Fix
- Introduced two new DTOs:
  - `InstructorRegistrationRequest`
  - `StudentRegistrationRequest`
- These DTOs exclude primitive `enabled`
- Newly created users default to `enabled = true` at the service layer

This avoids fragile request contracts and aligns better with API design best practices.

---

### 4. AuthorizationManager API Update
Spring Security API change in Spring Boot 4:
- ❌ `AuthorizationManager#check(...)` (removed)
- ✅ `AuthorizationManager#authorize(...)` (new)

All custom `AuthorizationManager` implementations were updated accordingly.

---

### 5. DevTools Live Reload
Spring Boot 4 disables Live Reload by default.

Added configuration:

```yaml
spring:
  devtools:
    livereload:
      enabled: true
```

This restores the previous local development experience.

---

### 6. Liveness & Readiness Probes
- Liveness and readiness probes are enabled by default in Spring Boot 4
- Health endpoint now exposes probe groups automatically

Disable if needed:

```yaml
management:
  endpoint:
    health:
      probes:
        enabled: false
```

---

### 7. Test Infrastructure Notes (For Completeness)
These changes were introduced in prior PRs but are required for Spring Boot 4 compatibility:

- `@SpringBootTest` no longer provides MockMvc support  
  - Explicit `@AutoConfigureMockMvc` is now required
- `@MockBean` / `@SpyBean` are deprecated  
  - Replaced with `@MockitoBean` / `@MockitoSpyBean`

Included here for traceability.

---

## ⚠️ Reviewer Notes
- This is a large but mostly mechanical framework upgrade
- No business logic changes beyond DTO safety fixes
- Please review dependency changes and Jackson-related updates carefully
