### PR TITLE
chore(db): add Flyway migrations for RAM schema

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -95,6 +95,14 @@
             <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,6 +9,13 @@ spring:
   devtools:
     livereload:
       enabled: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: true # On an existing schema, baseline at V1 so Flyway won’t rerun V1; on a fresh DB, V1 will execute.
+    baseline-version: 1
+    locations: classpath:db/migration
+    validate-on-migrate: true
+    clean-disabled: true
 server:
   port: 80
 api:

--- a/backend/src/main/resources/db/migration/V1__baseline.sql
+++ b/backend/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,217 @@
+-- Save current session settings and optimize for import
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+
+-- Table structure for table `activity`
+CREATE TABLE `activity` (
+                            `activity_id` int NOT NULL AUTO_INCREMENT,
+                            `actual_hours` double DEFAULT NULL,
+                            `category` tinyint DEFAULT NULL,
+                            `planned_hours` double DEFAULT NULL,
+                            `status` tinyint DEFAULT NULL,
+                            `student_id` int DEFAULT NULL,
+                            `team_team_id` int DEFAULT NULL,
+                            `created_at` datetime(6) DEFAULT NULL,
+                            `updated_at` datetime(6) DEFAULT NULL,
+                            `activity` varchar(255) DEFAULT NULL,
+                            `comments` varchar(255) DEFAULT NULL,
+                            `description` varchar(255) DEFAULT NULL,
+                            `week` varchar(255) DEFAULT NULL,
+                            PRIMARY KEY (`activity_id`),
+                            KEY `FKa5w9ku6jx44543pt6nok01dft` (`student_id`),
+                            KEY `FKracd6lriw4oaxdohvxlnr5jyl` (`team_team_id`),
+                            CONSTRAINT `FKa5w9ku6jx44543pt6nok01dft` FOREIGN KEY (`student_id`) REFERENCES `peer_evaluation_user` (`id`),
+                            CONSTRAINT `FKracd6lriw4oaxdohvxlnr5jyl` FOREIGN KEY (`team_team_id`) REFERENCES `team` (`team_id`),
+                            CONSTRAINT `activity_chk_1` CHECK ((`category` between 0 and 10)),
+                            CONSTRAINT `activity_chk_2` CHECK ((`status` between 0 and 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `course`
+CREATE TABLE `course` (
+                          `course_admin_id` int DEFAULT NULL,
+                          `course_id` int NOT NULL AUTO_INCREMENT,
+                          `course_description` varchar(255) DEFAULT NULL,
+                          `course_name` varchar(255) DEFAULT NULL,
+                          PRIMARY KEY (`course_id`),
+                          KEY `FKlb1wcxwkh479xpkq5x9k31r59` (`course_admin_id`),
+                          CONSTRAINT `FKlb1wcxwkh479xpkq5x9k31r59` FOREIGN KEY (`course_admin_id`) REFERENCES `peer_evaluation_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `course_instructor`
+CREATE TABLE `course_instructor` (
+                                     `course_id` int NOT NULL,
+                                     `instructor_id` int NOT NULL,
+                                     PRIMARY KEY (`course_id`,`instructor_id`),
+                                     KEY `FKq67rv0bdqr05g8bej32pmilq7` (`instructor_id`),
+                                     CONSTRAINT `FKeqej22fgwa29i98ucd9x9ycie` FOREIGN KEY (`course_id`) REFERENCES `course` (`course_id`),
+                                     CONSTRAINT `FKq67rv0bdqr05g8bej32pmilq7` FOREIGN KEY (`instructor_id`) REFERENCES `peer_evaluation_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `criterion`
+CREATE TABLE `criterion` (
+                             `course_course_id` int DEFAULT NULL,
+                             `criterion_id` int NOT NULL AUTO_INCREMENT,
+                             `max_score` double NOT NULL,
+                             `criterion` varchar(255) NOT NULL,
+                             `description` varchar(255) NOT NULL,
+                             PRIMARY KEY (`criterion_id`),
+                             KEY `FKsm5rifji7sn3a2cwe55lgekxc` (`course_course_id`),
+                             CONSTRAINT `FKsm5rifji7sn3a2cwe55lgekxc` FOREIGN KEY (`course_course_id`) REFERENCES `course` (`course_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- Table structure for table `peer_evaluation`
+--
+
+CREATE TABLE `peer_evaluation` (
+                                   `evaluatee_id` int DEFAULT NULL,
+                                   `evaluator_id` int DEFAULT NULL,
+                                   `peer_evaluation_id` int NOT NULL AUTO_INCREMENT,
+                                   `total_score` double DEFAULT NULL,
+                                   `created_at` datetime(6) DEFAULT NULL,
+                                   `updated_at` datetime(6) DEFAULT NULL,
+                                   `private_comment` varchar(255) DEFAULT NULL,
+                                   `public_comment` varchar(255) DEFAULT NULL,
+                                   `week` varchar(255) DEFAULT NULL,
+                                   PRIMARY KEY (`peer_evaluation_id`),
+                                   KEY `FKrk4h1o4pu3ei89ypwl23swbd3` (`evaluatee_id`),
+                                   KEY `FK1pflvjhop7lfak6hwnh2ldk9v` (`evaluator_id`),
+                                   CONSTRAINT `FK1pflvjhop7lfak6hwnh2ldk9v` FOREIGN KEY (`evaluator_id`) REFERENCES `peer_evaluation_user` (`id`),
+                                   CONSTRAINT `FKrk4h1o4pu3ei89ypwl23swbd3` FOREIGN KEY (`evaluatee_id`) REFERENCES `peer_evaluation_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `peer_evaluation_user`
+CREATE TABLE `peer_evaluation_user` (
+                                        `default_course_course_id` int DEFAULT NULL,
+                                        `default_section_section_id` int DEFAULT NULL,
+                                        `enabled` bit(1) NOT NULL,
+                                        `id` int NOT NULL AUTO_INCREMENT,
+                                        `section_section_id` int DEFAULT NULL,
+                                        `team_team_id` int DEFAULT NULL,
+                                        `dtype` varchar(31) NOT NULL,
+                                        `email` varchar(255) NOT NULL,
+                                        `first_name` varchar(255) NOT NULL,
+                                        `last_name` varchar(255) NOT NULL,
+                                        `password` varchar(255) NOT NULL,
+                                        `roles` varchar(255) DEFAULT NULL,
+                                        `username` varchar(255) NOT NULL,
+                                        PRIMARY KEY (`id`),
+                                        KEY `FKrakyek3pl9rvokurpa42ims1s` (`default_course_course_id`),
+                                        KEY `FKocua9ortgt5j7vlts2n0y2rsi` (`default_section_section_id`),
+                                        KEY `FK6kob0tbp2e39jtqsueb9wmrq8` (`section_section_id`),
+                                        KEY `FKs0r69hgtk6ge33ujevappqahk` (`team_team_id`),
+                                        CONSTRAINT `FK6kob0tbp2e39jtqsueb9wmrq8` FOREIGN KEY (`section_section_id`) REFERENCES `section` (`section_id`),
+                                        CONSTRAINT `FKocua9ortgt5j7vlts2n0y2rsi` FOREIGN KEY (`default_section_section_id`) REFERENCES `section` (`section_id`),
+                                        CONSTRAINT `FKrakyek3pl9rvokurpa42ims1s` FOREIGN KEY (`default_course_course_id`) REFERENCES `course` (`course_id`),
+                                        CONSTRAINT `FKs0r69hgtk6ge33ujevappqahk` FOREIGN KEY (`team_team_id`) REFERENCES `team` (`team_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `rating`
+CREATE TABLE `rating` (
+                          `actual_score` double DEFAULT NULL,
+                          `criterion_criterion_id` int DEFAULT NULL,
+                          `peer_evaluation_peer_evaluation_id` int DEFAULT NULL,
+                          `rating_id` int NOT NULL AUTO_INCREMENT,
+                          PRIMARY KEY (`rating_id`),
+                          KEY `FKnasjo68tk8iy6to628v1v8xxg` (`criterion_criterion_id`),
+                          KEY `FK2sauw46awdhv4mx0t7qi3j0fv` (`peer_evaluation_peer_evaluation_id`),
+                          CONSTRAINT `FK2sauw46awdhv4mx0t7qi3j0fv` FOREIGN KEY (`peer_evaluation_peer_evaluation_id`) REFERENCES `peer_evaluation` (`peer_evaluation_id`),
+                          CONSTRAINT `FKnasjo68tk8iy6to628v1v8xxg` FOREIGN KEY (`criterion_criterion_id`) REFERENCES `criterion` (`criterion_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `reset_password_token`
+CREATE TABLE `reset_password_token` (
+                                        `expiry_date` datetime(6) DEFAULT NULL,
+                                        `email` varchar(255) NOT NULL,
+                                        `token` varchar(255) DEFAULT NULL,
+                                        PRIMARY KEY (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `rubric`
+CREATE TABLE `rubric` (
+                          `course_course_id` int DEFAULT NULL,
+                          `rubric_id` int NOT NULL AUTO_INCREMENT,
+                          `rubric_name` varchar(255) NOT NULL,
+                          PRIMARY KEY (`rubric_id`),
+                          KEY `FKtggmi92tqjgxlihyhbg15xqd5` (`course_course_id`),
+                          CONSTRAINT `FKtggmi92tqjgxlihyhbg15xqd5` FOREIGN KEY (`course_course_id`) REFERENCES `course` (`course_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `rubric_criterion`
+CREATE TABLE `rubric_criterion` (
+                                    `criterion_id` int NOT NULL,
+                                    `rubric_id` int NOT NULL,
+                                    PRIMARY KEY (`criterion_id`,`rubric_id`),
+                                    KEY `FK5yqdms3yo15fswpve6wxjig16` (`rubric_id`),
+                                    CONSTRAINT `FK5yqdms3yo15fswpve6wxjig16` FOREIGN KEY (`rubric_id`) REFERENCES `rubric` (`rubric_id`),
+                                    CONSTRAINT `FKgmvn7r0e5v75hdhkk1bh720p3` FOREIGN KEY (`criterion_id`) REFERENCES `criterion` (`criterion_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `section`
+CREATE TABLE `section` (
+                           `course_course_id` int DEFAULT NULL,
+                           `end_date` date DEFAULT NULL,
+                           `rubric_rubric_id` int DEFAULT NULL,
+                           `section_id` int NOT NULL AUTO_INCREMENT,
+                           `start_date` date DEFAULT NULL,
+                           `section_name` varchar(255) DEFAULT NULL,
+                           `war_weekly_due_day` varchar(20) DEFAULT NULL,
+                           `war_due_time` time DEFAULT NULL,
+                           `peer_evaluation_weekly_due_day` varchar(20) DEFAULT NULL,
+                           `peer_evaluation_due_time` time DEFAULT NULL,
+                           `is_active` tinyint(1) DEFAULT '0',
+                           PRIMARY KEY (`section_id`),
+                           KEY `FKcaob2rpl5w0q76503ake08qdn` (`course_course_id`),
+                           KEY `FK3ddg24nw0m8qqfn3tqelv9s2y` (`rubric_rubric_id`),
+                           CONSTRAINT `FK3ddg24nw0m8qqfn3tqelv9s2y` FOREIGN KEY (`rubric_rubric_id`) REFERENCES `rubric` (`rubric_id`),
+                           CONSTRAINT `FKcaob2rpl5w0q76503ake08qdn` FOREIGN KEY (`course_course_id`) REFERENCES `course` (`course_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `section_active_weeks`
+CREATE TABLE `section_active_weeks` (
+                                        `my_row_id` bigint unsigned NOT NULL AUTO_INCREMENT INVISIBLE,
+                                        `section_section_id` int NOT NULL,
+                                        `active_weeks` varchar(255) DEFAULT NULL,
+                                        PRIMARY KEY (`my_row_id`),
+                                        KEY `FK1d092prm0mkywkto40cplsmm5` (`section_section_id`),
+                                        CONSTRAINT `FK1d092prm0mkywkto40cplsmm5` FOREIGN KEY (`section_section_id`) REFERENCES `section` (`section_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `section_instructor`
+CREATE TABLE `section_instructor` (
+                                      `instructor_id` int NOT NULL,
+                                      `section_id` int NOT NULL,
+                                      PRIMARY KEY (`instructor_id`,`section_id`),
+                                      KEY `FKpf29kgm7o3gnc40yqthc9fyov` (`section_id`),
+                                      CONSTRAINT `FKi4e06rsa3d14b5f1ekn2cxp91` FOREIGN KEY (`instructor_id`) REFERENCES `peer_evaluation_user` (`id`),
+                                      CONSTRAINT `FKpf29kgm7o3gnc40yqthc9fyov` FOREIGN KEY (`section_id`) REFERENCES `section` (`section_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `team`
+CREATE TABLE `team` (
+                        `instructor_id` int DEFAULT NULL,
+                        `section_section_id` int DEFAULT NULL,
+                        `team_id` int NOT NULL AUTO_INCREMENT,
+                        `description` varchar(255) DEFAULT NULL,
+                        `team_name` varchar(255) DEFAULT NULL,
+                        `team_website_url` varchar(255) DEFAULT NULL,
+                        PRIMARY KEY (`team_id`),
+                        KEY `FKc7peb88quevji666ynwc6lvjx` (`instructor_id`),
+                        KEY `FKpefqxvyo2oneigiwjniorbshe` (`section_section_id`),
+                        CONSTRAINT `FKc7peb88quevji666ynwc6lvjx` FOREIGN KEY (`instructor_id`) REFERENCES `peer_evaluation_user` (`id`),
+                        CONSTRAINT `FKpefqxvyo2oneigiwjniorbshe` FOREIGN KEY (`section_section_id`) REFERENCES `section` (`section_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `user_invitation`
+CREATE TABLE `user_invitation` (
+                                   `course_id` int DEFAULT NULL,
+                                   `section_id` int DEFAULT NULL,
+                                   `email` varchar(255) NOT NULL,
+                                   `role` varchar(255) DEFAULT NULL,
+                                   `token` varchar(255) DEFAULT NULL,
+                                   PRIMARY KEY (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Restore original session settings
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;

--- a/backend/src/main/resources/db/migration/V2__ram_schema.sql
+++ b/backend/src/main/resources/db/migration/V2__ram_schema.sql
@@ -1,0 +1,251 @@
+-- Save current session settings and optimize for import
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+
+-- Table structure for table `artifact_key_sequence`
+CREATE TABLE `artifact_key_sequence` (
+  `team_team_id` int NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `next_number` bigint NOT NULL,
+  `version` bigint DEFAULT NULL,
+  `type` enum('ASSUMPTION','BUSINESS_OBJECTIVE','BUSINESS_OPPORTUNITY','BUSINESS_PROBLEM','BUSINESS_RISK','BUSINESS_RULE','CONSTRAINT','DATA_REQUIREMENT','EXTERNAL_INTERFACE_REQUIREMENT','FEATURE','FUNCTIONAL_REQUIREMENT','GLOSSARY_TERM','OTHER','POSTCONDITION','PRECONDITION','QUALITY_ATTRIBUTE','RISK','STAKEHOLDER','SUCCESS_METRIC','USER_STORY','USE_CASE','VISION_STATEMENT') NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK9yvou32dahq4ftyfbne3xbbhe` (`team_team_id`),
+  CONSTRAINT `FK9yvou32dahq4ftyfbne3xbbhe` FOREIGN KEY (`team_team_id`) REFERENCES `team` (`team_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `artifact_link`
+CREATE TABLE `artifact_link` (
+  `created_by_id` int DEFAULT NULL,
+  `team_team_id` int DEFAULT NULL,
+  `updated_by_id` int DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `source_artifact_id` bigint DEFAULT NULL,
+  `target_artifact_id` bigint DEFAULT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `notes` longtext,
+  `type` enum('DERIVES_FROM','IMPACTS','MITIGATES','MOTIVATES','REALIZES','REFERENCES') DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FKfk27l3wka0ybawed08u7b2k47` (`created_by_id`),
+  KEY `FKlmvsyqhc3lp86oxaqadwuulu7` (`source_artifact_id`),
+  KEY `FKtjm34sp40pd32928mvbddesj0` (`target_artifact_id`),
+  KEY `FKt65eowb7ay5ul9xeftfdg528b` (`team_team_id`),
+  KEY `FK3l18b87sm98qb1x0ck70oe83w` (`updated_by_id`),
+  CONSTRAINT `FK3l18b87sm98qb1x0ck70oe83w` FOREIGN KEY (`updated_by_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FKfk27l3wka0ybawed08u7b2k47` FOREIGN KEY (`created_by_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FKlmvsyqhc3lp86oxaqadwuulu7` FOREIGN KEY (`source_artifact_id`) REFERENCES `requirement_artifact` (`id`),
+  CONSTRAINT `FKt65eowb7ay5ul9xeftfdg528b` FOREIGN KEY (`team_team_id`) REFERENCES `team` (`team_id`),
+  CONSTRAINT `FKtjm34sp40pd32928mvbddesj0` FOREIGN KEY (`target_artifact_id`) REFERENCES `requirement_artifact` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `comment`
+CREATE TABLE `comment` (
+  `author_id` int DEFAULT NULL,
+  `comment_index` int DEFAULT NULL,
+  `comment_thread_id` bigint DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `content` longtext,
+  PRIMARY KEY (`id`),
+  KEY `FKo1gq8i4ywpw214oq700fqhh7j` (`author_id`),
+  KEY `FKryuhdv7b3hva1nt77ndwniq9t` (`comment_thread_id`),
+  CONSTRAINT `FKo1gq8i4ywpw214oq700fqhh7j` FOREIGN KEY (`author_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FKryuhdv7b3hva1nt77ndwniq9t` FOREIGN KEY (`comment_thread_id`) REFERENCES `comment_thread` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `comment_thread`
+CREATE TABLE `comment_thread` (
+  `created_by_id` int DEFAULT NULL,
+  `team_team_id` int DEFAULT NULL,
+  `updated_by_id` int DEFAULT NULL,
+  `artifact_id` bigint DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `document_id` bigint DEFAULT NULL,
+  `document_section_id` bigint DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `status` enum('OPEN','RESOLVED') DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FKmtynrmdah22h09nshi8css78c` (`artifact_id`),
+  KEY `FK6xj7onmcxp9kbuoy0tuy9t7kx` (`created_by_id`),
+  KEY `FKsosbiyjb50atlkgqkcu74tv2d` (`document_id`),
+  KEY `FK95pn34vdy92lxr4utp4bmnq8x` (`document_section_id`),
+  KEY `FKl1p6jsuyiqf06nvxda513y5ye` (`team_team_id`),
+  KEY `FK5br1qn14ol7adu9e7ycc58nuq` (`updated_by_id`),
+  CONSTRAINT `FK5br1qn14ol7adu9e7ycc58nuq` FOREIGN KEY (`updated_by_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FK6xj7onmcxp9kbuoy0tuy9t7kx` FOREIGN KEY (`created_by_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FK95pn34vdy92lxr4utp4bmnq8x` FOREIGN KEY (`document_section_id`) REFERENCES `document_section` (`id`),
+  CONSTRAINT `FKl1p6jsuyiqf06nvxda513y5ye` FOREIGN KEY (`team_team_id`) REFERENCES `team` (`team_id`),
+  CONSTRAINT `FKmtynrmdah22h09nshi8css78c` FOREIGN KEY (`artifact_id`) REFERENCES `requirement_artifact` (`id`),
+  CONSTRAINT `FKsosbiyjb50atlkgqkcu74tv2d` FOREIGN KEY (`document_id`) REFERENCES `requirement_document` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `document_section`
+CREATE TABLE `document_section` (
+  `created_by_id` int DEFAULT NULL,
+  `section_index` int DEFAULT NULL,
+  `updated_by_id` int DEFAULT NULL,
+  `version` int DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `document_id` bigint DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `section_key` varchar(255) DEFAULT NULL,
+  `title` varchar(255) DEFAULT NULL,
+  `content` longtext,
+  `guidance` longtext,
+  `type` enum('LIST','RICH_TEXT') DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FKopy1pibbrjq6912migimrxn4q` (`created_by_id`),
+  KEY `FKsupkor7l05adux2149nk6hr61` (`document_id`),
+  KEY `FKp7m4ugv3cnoq4lkpsj0rr7kb9` (`updated_by_id`),
+  CONSTRAINT `FKopy1pibbrjq6912migimrxn4q` FOREIGN KEY (`created_by_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FKp7m4ugv3cnoq4lkpsj0rr7kb9` FOREIGN KEY (`updated_by_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FKsupkor7l05adux2149nk6hr61` FOREIGN KEY (`document_id`) REFERENCES `requirement_document` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `document_section_lock`
+CREATE TABLE `document_section_lock` (
+  `locked_by_id` int DEFAULT NULL,
+  `version` int DEFAULT NULL,
+  `document_section_id` bigint NOT NULL,
+  `expires_at` datetime(6) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `locked_at` datetime(6) DEFAULT NULL,
+  `reason` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UKrb445eus6nqmm60wpywpq56rg` (`document_section_id`),
+  KEY `FKpl9fmr2r14xv6va55udh5nv2o` (`locked_by_id`),
+  CONSTRAINT `FK903qobnvgl1ikeb49159pi2gj` FOREIGN KEY (`document_section_id`) REFERENCES `document_section` (`id`),
+  CONSTRAINT `FKpl9fmr2r14xv6va55udh5nv2o` FOREIGN KEY (`locked_by_id`) REFERENCES `peer_evaluation_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `requirement_artifact`
+CREATE TABLE `requirement_artifact` (
+  `artifact_index` int DEFAULT NULL,
+  `created_by_id` int DEFAULT NULL,
+  `team_team_id` int DEFAULT NULL,
+  `updated_by_id` int DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `source_document_section_id` bigint DEFAULT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `artifact_key` varchar(255) DEFAULT NULL,
+  `title` varchar(255) DEFAULT NULL,
+  `content` longtext,
+  `notes` longtext,
+  `priority` enum('CRITICAL','HIGH','LOW','MEDIUM') DEFAULT NULL,
+  `type` enum('ASSUMPTION','BUSINESS_OBJECTIVE','BUSINESS_OPPORTUNITY','BUSINESS_PROBLEM','BUSINESS_RISK','BUSINESS_RULE','CONSTRAINT','DATA_REQUIREMENT','EXTERNAL_INTERFACE_REQUIREMENT','FEATURE','FUNCTIONAL_REQUIREMENT','GLOSSARY_TERM','OTHER','POSTCONDITION','PRECONDITION','QUALITY_ATTRIBUTE','RISK','STAKEHOLDER','SUCCESS_METRIC','USER_STORY','USE_CASE','VISION_STATEMENT') DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK8hc7c24926q0j32qwc13lc6cb` (`created_by_id`),
+  KEY `FKpfiuqfmv3psyacg13htervxj6` (`source_document_section_id`),
+  KEY `FKipwvw342vl86gt02me9k0vsse` (`team_team_id`),
+  KEY `FK5ljsaep9u4qyrgf794vkbctbl` (`updated_by_id`),
+  CONSTRAINT `FK5ljsaep9u4qyrgf794vkbctbl` FOREIGN KEY (`updated_by_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FK8hc7c24926q0j32qwc13lc6cb` FOREIGN KEY (`created_by_id`) REFERENCES `peer_evaluation_user` (`id`),
+  CONSTRAINT `FKipwvw342vl86gt02me9k0vsse` FOREIGN KEY (`team_team_id`) REFERENCES `team` (`team_id`),
+  CONSTRAINT `FKpfiuqfmv3psyacg13htervxj6` FOREIGN KEY (`source_document_section_id`) REFERENCES `document_section` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `requirement_document`
+CREATE TABLE `requirement_document` (
+  `team_team_id` int DEFAULT NULL,
+  `version` int DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `document_key` varchar(255) DEFAULT NULL,
+  `title` varchar(255) DEFAULT NULL,
+  `status` enum('DRAFT','RETURNED','SUBMITTED') DEFAULT NULL,
+  `type` enum('BUSINESS_RULES','GLOSSARY','SRS','USER_STORIES','USE_CASES','VISION_SCOPE') DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FKex4umeqic43w8thr6f7au59y4` (`team_team_id`),
+  CONSTRAINT `FKex4umeqic43w8thr6f7au59y4` FOREIGN KEY (`team_team_id`) REFERENCES `team` (`team_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `use_case`
+CREATE TABLE `use_case` (
+  `version` int DEFAULT NULL,
+  `artifact_id` bigint NOT NULL,
+  `primary_actor_id` bigint DEFAULT NULL,
+  `use_case_trigger` longtext,
+  PRIMARY KEY (`artifact_id`),
+  KEY `FKby3rbcs00t8s24y2yvju5hn1x` (`primary_actor_id`),
+  CONSTRAINT `FK93j76hn9kmnx03486akmbw08a` FOREIGN KEY (`artifact_id`) REFERENCES `requirement_artifact` (`id`),
+  CONSTRAINT `FKby3rbcs00t8s24y2yvju5hn1x` FOREIGN KEY (`primary_actor_id`) REFERENCES `requirement_artifact` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `use_case_extension`
+CREATE TABLE `use_case_extension` (
+  `extension_index` int DEFAULT NULL,
+  `resume_step_no` int DEFAULT NULL,
+  `base_step_id` bigint DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `label` varchar(255) DEFAULT NULL,
+  `condition_text` longtext,
+  `extension_exit` enum('END_FAILURE','END_SUCCESS','RESUME') DEFAULT NULL,
+  `kind` enum('ALTERNATE','EXCEPTION') DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FKghc6ff42eittvpjhr4p7vfwi8` (`base_step_id`),
+  CONSTRAINT `FKghc6ff42eittvpjhr4p7vfwi8` FOREIGN KEY (`base_step_id`) REFERENCES `use_case_main_step` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `use_case_extension_step`
+CREATE TABLE `use_case_extension_step` (
+  `extension_step_index` int DEFAULT NULL,
+  `extension_id` bigint DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `actor` varchar(255) DEFAULT NULL,
+  `action_text` longtext,
+  PRIMARY KEY (`id`),
+  KEY `FKg0ve3dvmytoxmdmwnutxkixvb` (`extension_id`),
+  CONSTRAINT `FKg0ve3dvmytoxmdmwnutxkixvb` FOREIGN KEY (`extension_id`) REFERENCES `use_case_extension` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `use_case_main_step`
+CREATE TABLE `use_case_main_step` (
+  `main_step_index` int DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `use_case_artifact_id` bigint DEFAULT NULL,
+  `actor` varchar(255) DEFAULT NULL,
+  `action_text` longtext,
+  PRIMARY KEY (`id`),
+  KEY `FKavurbeiwfm8yy9pyxtgxvat34` (`use_case_artifact_id`),
+  CONSTRAINT `FKavurbeiwfm8yy9pyxtgxvat34` FOREIGN KEY (`use_case_artifact_id`) REFERENCES `use_case` (`artifact_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `use_case_postcondition`
+CREATE TABLE `use_case_postcondition` (
+  `postcondition_artifact_id` bigint NOT NULL,
+  `use_case_id` bigint NOT NULL,
+  PRIMARY KEY (`postcondition_artifact_id`,`use_case_id`),
+  KEY `FK3i8xwyaajf5pgjxvy8d2j4x5s` (`use_case_id`),
+  CONSTRAINT `FK3i8xwyaajf5pgjxvy8d2j4x5s` FOREIGN KEY (`use_case_id`) REFERENCES `use_case` (`artifact_id`),
+  CONSTRAINT `FKavn1ufxtfgrwvnlwos92hniyo` FOREIGN KEY (`postcondition_artifact_id`) REFERENCES `requirement_artifact` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `use_case_precondition`
+CREATE TABLE `use_case_precondition` (
+  `precondition_artifact_id` bigint NOT NULL,
+  `use_case_id` bigint NOT NULL,
+  PRIMARY KEY (`precondition_artifact_id`,`use_case_id`),
+  KEY `FK86gruuyappjqyd565esquxqrv` (`use_case_id`),
+  CONSTRAINT `FK86gruuyappjqyd565esquxqrv` FOREIGN KEY (`use_case_id`) REFERENCES `use_case` (`artifact_id`),
+  CONSTRAINT `FKmw70ecnof4ry4unj25evv9hmd` FOREIGN KEY (`precondition_artifact_id`) REFERENCES `requirement_artifact` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Table structure for table `use_case_secondary_actor`
+CREATE TABLE `use_case_secondary_actor` (
+  `stakeholder_artifact_id` bigint NOT NULL,
+  `use_case_id` bigint NOT NULL,
+  PRIMARY KEY (`stakeholder_artifact_id`,`use_case_id`),
+  KEY `FK7jkv135phrnchoaly2cccyb0c` (`use_case_id`),
+  CONSTRAINT `FK4bdeaheefktd5pcsaf7m5yjer` FOREIGN KEY (`stakeholder_artifact_id`) REFERENCES `requirement_artifact` (`id`),
+  CONSTRAINT `FK7jkv135phrnchoaly2cccyb0c` FOREIGN KEY (`use_case_id`) REFERENCES `use_case` (`artifact_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Restore original session settings
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;


### PR DESCRIPTION
## 🗄️ Add Database Schema for Requirements Authoring & Management (RAM)

### Summary
This PR introduces **Flyway** for database schema version control and adds the missing database schema to support the **Requirements Authoring & Management (RAM)** backend feature already deployed to production.

---

## 🔧 Key Changes

### 1. Flyway Integration (Spring Boot 4)
Spring Boot 4 requires explicit Flyway starter configuration.

#### Dependencies Added
- `spring-boot-starter-flyway` – Provides Flyway auto-configuration
- `flyway-mysql` – MySQL database support

#### Configuration
```yaml
spring:
  flyway:
    enabled: true
    baseline-on-migrate: true
    baseline-version: 1
    clean-disabled: true
  jpa:
    hibernate:
      ddl-auto: none
```

**Key Settings:**
- `baseline-on-migrate=true` – Required for existing production database (prevents re-execution of baseline)
- `clean-disabled=true` – Safety measure to prevent accidental schema drops
- `ddl-auto=none` – Flyway now manages all schema changes

---

### 2. Database Migrations

#### V1__baseline.sql
- Documents current production schema in Project Pulse (15 existing tables)
- Will **NOT execute** on production (baseline marks it as already applied)
- Serves as reference point for future migrations

#### V2__ram_schema.sql
- Adds **15 new tables** for RAM feature
- Will **execute on production** during deployment
- No modifications to existing tables (backward compatible)

**New Tables:**
- `artifact_key_sequence` – Sequential ID generation per team
- `requirement_document` – Requirements documents (Vision, SRS, Use Cases, etc.)
- `document_section` – Document sections with rich content
- `document_section_lock` – Collaborative editing locks
- `requirement_artifact` – Requirements, features, stakeholders, etc.
- `artifact_link` – Artifact relationships (derives from, impacts, etc.)
- `comment_thread` – Discussion threads on artifacts/documents
- `comment` – Individual comments
- `use_case` – Use case details
- `use_case_main_step` – Main flow steps
- `use_case_extension` – Alternate/exception flows
- `use_case_extension_step` – Extension flow steps
- `use_case_precondition` – Prerequisites
- `use_case_postcondition` – Expected outcomes
- `use_case_secondary_actor` – Additional actors

---

## 📊 Deployment Impact

- **Risk Level:** Low
- **Database Changes:** Adds 15 new tables only (no modifications to existing schema)
- **Backward Compatible:** Yes (existing functionality unaffected)
- **Downtime:** None (migration runs during application startup)
- **Rollback Plan:** Redeploy previous version (new tables remain but unused)

---

## ✅ Testing

- [x] Tested locally with production database copy
- [x] Verified V1 baseline does not execute on existing database
- [x] Verified V2 migration successfully creates all 15 tables
- [x] Confirmed all foreign key relationships are valid
- [x] Validated SQL syntax

---

## ⚠️ Reviewer Notes

- RAM backend code is already in production; this PR adds the missing database layer
- Flyway will automatically run migrations during Azure deployment
- **Pre-deployment:** Ensure database backup is available
- **Post-deployment:** Verify `flyway_schema_history` table shows both migrations applied

---

## 🔍 Post-Deployment Verification
```sql
-- Verify Flyway history
SELECT * FROM flyway_schema_history ORDER BY installed_rank;

-- Expected output:
-- installed_rank | version | description | type     | script
-- 1              | 1       | baseline    | BASELINE | << Flyway Baseline >>
-- 2              | 2       | ram schema  | SQL      | V2__ram_schema.sql

-- Verify new tables exist (should return 15)
SELECT COUNT(*) FROM information_schema.tables 
WHERE table_schema = 'project-pulse' 
AND table_name IN (
    'artifact_key_sequence', 'artifact_link', 'comment', 'comment_thread',
    'document_section', 'document_section_lock', 'requirement_artifact',
    'requirement_document', 'use_case', 'use_case_extension',
    'use_case_extension_step', 'use_case_main_step', 'use_case_postcondition',
    'use_case_precondition', 'use_case_secondary_actor'
);
```