### PR TITLE
fix: clear SecurityContextHolder in unit tests to prevent context leak

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -174,15 +174,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <!--Prevent test cases errors during Maven building in CI-->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
             </plugin>

--- a/backend/src/test/java/team/projectpulse/evaluation/EvaluationServiceTest.java
+++ b/backend/src/test/java/team/projectpulse/evaluation/EvaluationServiceTest.java
@@ -1,5 +1,6 @@
 package team.projectpulse.evaluation;
 
+import org.junit.jupiter.api.AfterEach;
 import team.projectpulse.instructor.Instructor;
 import team.projectpulse.rubric.Criterion;
 import team.projectpulse.rubric.Rating;
@@ -288,6 +289,11 @@ class EvaluationServiceTest {
         PeerEvaluation peerEvaluation14 = new PeerEvaluation("2023-W32", jerry, eric, jerryEricRatingsW32, "eric needs to attend meeting!", "I am Jerry.");
 
         this.ericsW32Evaluations = List.of(peerEvaluation12, peerEvaluation13, peerEvaluation14);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext(); // Clear the security context after each test to avoid interference between tests
     }
 
     @Test

--- a/backend/src/test/java/team/projectpulse/instructor/InstructorServiceTest.java
+++ b/backend/src/test/java/team/projectpulse/instructor/InstructorServiceTest.java
@@ -1,5 +1,6 @@
 package team.projectpulse.instructor;
 
+import org.junit.jupiter.api.AfterEach;
 import team.projectpulse.course.Course;
 import team.projectpulse.course.CourseRepository;
 import team.projectpulse.section.Section;
@@ -79,6 +80,11 @@ class InstructorServiceTest {
         instructor2.setDefaultSection(this.section);
 
         this.instructors = List.of(instructor1, instructor2);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext(); // Clear the security context after each test to avoid interference between tests
     }
 
     @Test

--- a/backend/src/test/java/team/projectpulse/student/StudentServiceTest.java
+++ b/backend/src/test/java/team/projectpulse/student/StudentServiceTest.java
@@ -1,5 +1,6 @@
 package team.projectpulse.student;
 
+import org.junit.jupiter.api.AfterEach;
 import team.projectpulse.instructor.Instructor;
 import team.projectpulse.section.Section;
 import team.projectpulse.section.SectionRepository;
@@ -65,6 +66,11 @@ class StudentServiceTest {
         Student rosendo = new Student("rosendo", "Rosendo", "Maxwell", "r.maxwell@abc.edu", "123456", true, "student");
 
         this.students = List.of(john, eric, jerry, woody, amanda, cora, agustin, mavis, mary, rosendo);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext(); // Clear the security context after each test to avoid interference between tests
     }
 
     @Test


### PR DESCRIPTION
@
## Summary

- Add `@AfterEach` tearDown to `EvaluationServiceTest`, `StudentServiceTest`, and `InstructorServiceTest` to clear `SecurityContextHolder` after each test, preventing stale authentication from leaking into integration tests via thread-local storage
- Remove the `reuseForks`/`forkCount` Surefire workaround from `pom.xml` now that the root cause is fixed, restoring faster test execution

Closes #52

## Test plan

- [x] Run full backend test suite (`mvnw.cmd test`) — all tests pass
- [x] Verify CI pipeline passes without the Surefire workaround
@