### PR TITLE
refactor: replace @DirtiesContext with shared containers and @Transactional rollback

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -114,22 +114,20 @@ class FooServiceTest {
 ```
 
 ### Integration Tests (`*IntegrationTest.java`)
+
+All integration tests extend `AbstractIntegrationTest`, which provides:
+- **Shared containers** — `SharedContainers` starts a single MySQL and Mailpit container per JVM (singleton pattern), shared by all test classes
+- **`@Transactional` rollback** — each test runs in a transaction that rolls back automatically, restoring the DataInitializer-seeded state without needing `@DirtiesContext`
+- **Common annotations** — `@SpringBootTest`, `@AutoConfigureMockMvc`, `@ActiveProfiles("dev")`, `@Tag("integration")`
+
 ```java
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Foo API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-public class FooIntegrationTest {
+public class FooIntegrationTest extends AbstractIntegrationTest {
     @Autowired MockMvc mockMvc;
     @Autowired JsonMapper jsonMapper;
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     String adminToken;
     String studentToken;
@@ -153,4 +151,4 @@ public class FooIntegrationTest {
 }
 ```
 
-Integration tests use Testcontainers (MySQL 8.0), seed data from `DataInitializer`, and authenticate via HTTP Basic to get JWT tokens for subsequent requests. Tests verify both the `flag` and `code` fields in the `Result` response. Use `@DirtiesContext` on tests that modify state and could affect other tests.
+Integration tests use Testcontainers (MySQL 8.0), seed data from `DataInitializer`, and authenticate via HTTP Basic to get JWT tokens for subsequent requests. Tests verify both the `flag` and `code` fields in the `Result` response. Do **not** use `@DirtiesContext` — the `@Transactional` rollback on the base class handles database reset automatically.

--- a/backend/src/test/java/team/projectpulse/AbstractIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/AbstractIntegrationTest.java
@@ -1,0 +1,40 @@
+package team.projectpulse;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+
+/**
+ * Base class for all integration tests. Provides:
+ * <ul>
+ *   <li>Shared MySQL and Mailpit containers via {@link SharedContainers} (started once per JVM)</li>
+ *   <li>{@code @Transactional} rollback after each test — restores DataInitializer-seeded state
+ *       without the cost of {@code @DirtiesContext} (which would recreate the entire Spring context)</li>
+ *   <li>Common annotations: {@code @SpringBootTest}, {@code @AutoConfigureMockMvc},
+ *       {@code @ActiveProfiles("dev")}, {@code @Tag("integration")}</li>
+ * </ul>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@Tag("integration")
+@Transactional
+public abstract class AbstractIntegrationTest {
+
+    @ServiceConnection
+    static final MySQLContainer<?> mysql = SharedContainers.MYSQL;
+
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.mail.host", SharedContainers.MAILPIT::getHost);
+        registry.add("spring.mail.port", () -> SharedContainers.MAILPIT.getMappedPort(1025));
+    }
+
+}

--- a/backend/src/test/java/team/projectpulse/ProjectPulseApplicationTests.java
+++ b/backend/src/test/java/team/projectpulse/ProjectPulseApplicationTests.java
@@ -1,21 +1,8 @@
 package team.projectpulse;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
-@SpringBootTest
-@Testcontainers
-class ProjectPulseApplicationTests {
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
-    
+class ProjectPulseApplicationTests extends AbstractIntegrationTest {
 
     @Test
     void contextLoads() {

--- a/backend/src/test/java/team/projectpulse/SharedContainers.java
+++ b/backend/src/test/java/team/projectpulse/SharedContainers.java
@@ -1,0 +1,27 @@
+package team.projectpulse;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Singleton containers shared by all integration tests. Started once per JVM — avoids
+ * spinning up a new MySQL/Mailpit container per test class.
+ */
+public final class SharedContainers {
+
+    public static final MySQLContainer<?> MYSQL = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
+
+    public static final GenericContainer<?> MAILPIT = new GenericContainer<>(DockerImageName.parse("axllent/mailpit"))
+            .withExposedPorts(1025, 8025);
+
+    static {
+        MYSQL.start();
+        MAILPIT.start();
+    }
+
+
+    private SharedContainers() {
+    }
+
+}

--- a/backend/src/test/java/team/projectpulse/activity/ActivityIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/activity/ActivityIntegrationTest.java
@@ -1,26 +1,17 @@
 package team.projectpulse.activity;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -36,13 +27,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Activity API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-public class ActivityIntegrationTest {
+public class ActivityIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -60,10 +46,6 @@ public class ActivityIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     @BeforeEach
     void setUp() throws Exception {
@@ -228,7 +210,6 @@ public class ActivityIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testStudentJohnAddActivity() throws Exception {
         // Given
         Map<String, Object> activityDto = new HashMap<>();
@@ -259,7 +240,6 @@ public class ActivityIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testStudentJohnUpdatesOwnActivity() throws Exception {
         // Given
         Map<String, Object> activityDto = new HashMap<>();
@@ -310,7 +290,6 @@ public class ActivityIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testStudentJohnDeletesOwnActivity() throws Exception {
         this.mockMvc.perform(delete(this.baseUrl + "/activities/1").accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(true))

--- a/backend/src/test/java/team/projectpulse/course/CourseIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/course/CourseIntegrationTest.java
@@ -1,34 +1,22 @@
 package team.projectpulse.course;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MySQLContainer;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,13 +26,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Course API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-class CourseIntegrationTest {
+class CourseIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -60,21 +43,6 @@ class CourseIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
-
-    @Container
-    static final GenericContainer<?> mailpit = new GenericContainer<>(DockerImageName.parse("axllent/mailpit"))
-            .withExposedPorts(1025, 8025);
-
-
-    @DynamicPropertySource
-    static void setMailpitProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.mail.host", mailpit::getHost);
-        registry.add("spring.mail.port", () -> mailpit.getMappedPort(1025));
-    }
 
     @BeforeEach
     void setUp() throws Exception {
@@ -185,7 +153,7 @@ class CourseIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void adminBingyangAddCourse() throws Exception {
         // Given
         Map<String, String> courseDto = new HashMap<>();
@@ -219,7 +187,7 @@ class CourseIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void adminBingyangUpdateCourse() throws Exception {
         // Given
         Map<String, String> courseDto = new HashMap<>();

--- a/backend/src/test/java/team/projectpulse/evaluation/EvaluationIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/evaluation/EvaluationIntegrationTest.java
@@ -1,12 +1,8 @@
 package team.projectpulse.evaluation;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.evaluation.dto.PeerEvaluationDto;
 import team.projectpulse.evaluation.dto.RatingDto;
 import team.projectpulse.system.StatusCode;
@@ -14,16 +10,11 @@ import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -41,13 +32,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Evaluation API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-public class EvaluationIntegrationTest {
+public class EvaluationIntegrationTest extends AbstractIntegrationTest {
 
     /**
      * @MockitoSpyBean creates a Mockito spy and registers it as the active Spring bean.
@@ -74,10 +60,6 @@ public class EvaluationIntegrationTest {
     @Value("${api.endpoint.base-url}")
     String baseUrl;
 
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
-
 
     @BeforeEach
     void setUp() throws Exception {
@@ -101,7 +83,7 @@ public class EvaluationIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void testStudentJohnAddEvaluation() throws Exception {
         List<RatingDto> ratingDtos = List.of(
                 new RatingDto(null, 1, 4.0),
@@ -265,7 +247,7 @@ public class EvaluationIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void testEvaluatorJohnUpdatesOwnEvaluation() throws Exception {
         List<RatingDto> ratingDtos = List.of(
                 new RatingDto(1, 1, 4.0),

--- a/backend/src/test/java/team/projectpulse/instructor/InstructorIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/instructor/InstructorIntegrationTest.java
@@ -1,31 +1,22 @@
 package team.projectpulse.instructor;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MySQLContainer;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,13 +26,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Instructor API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-class InstructorIntegrationTest {
+class InstructorIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -57,10 +43,6 @@ class InstructorIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
 
     @BeforeEach
@@ -140,7 +122,6 @@ class InstructorIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testAddInstructor() throws Exception {
         Map<String, String> instructorDto = new HashMap<>();
         instructorDto.put("username", "e.musk@abc.edu");
@@ -243,7 +224,6 @@ class InstructorIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testAdminBingyangUpdatesOwnInfo() throws Exception {
         Map<String, Object> instructorDto = new HashMap<>();
         instructorDto.put("username", "b.wei@abc.edu");
@@ -271,7 +251,6 @@ class InstructorIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testInstructorBillUpdatesOwnInfo() throws Exception {
         Map<String, Object> instructorDto = new HashMap<>();
         instructorDto.put("username", "b.gates@abc.edu");
@@ -317,7 +296,6 @@ class InstructorIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testAdminBingyangSetDefaultSection() throws Exception {
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/instructors/sections/1/default").accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
@@ -360,7 +338,6 @@ class InstructorIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testAdminBingyangSetDefaultCourse() throws Exception {
         // When and then
         this.mockMvc.perform(put(this.baseUrl + "/instructors/courses/2/default").accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))

--- a/backend/src/test/java/team/projectpulse/ram/collabration/CommentControllerTest.java
+++ b/backend/src/test/java/team/projectpulse/ram/collabration/CommentControllerTest.java
@@ -6,20 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
@@ -27,11 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
-@ActiveProfiles(value = "dev")
-public class CommentControllerTest {
+public class CommentControllerTest extends AbstractIntegrationTest {
     @Autowired
     MockMvc mockMvc;
 
@@ -47,10 +35,6 @@ public class CommentControllerTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     @BeforeEach
     void setUp() throws Exception {
@@ -107,7 +91,6 @@ public class CommentControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void createCommentThreadForDocument() throws Exception {
         String json = """
                 {
@@ -141,7 +124,6 @@ public class CommentControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void createCommentThreadForDocumentSection() throws Exception {
         String json = """
                 {
@@ -206,7 +188,6 @@ public class CommentControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void addCommentToACommentThread() throws Exception {
         String addCommentJson = """
                 { "content": "Sure - but let's define it in the glossary." }
@@ -293,7 +274,6 @@ public class CommentControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void deleteComment() throws Exception {
         this.mockMvc.perform(delete(this.baseUrl + "/teams/1/comment-threads/1/comments/2")
                         .accept(MediaType.APPLICATION_JSON)
@@ -311,7 +291,6 @@ public class CommentControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void deleteCommentThread() throws Exception {
         this.mockMvc.perform(delete(this.baseUrl + "/teams/1/comment-threads/1")
                         .accept(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/team/projectpulse/ram/document/DocumentControllerTest.java
+++ b/backend/src/test/java/team/projectpulse/ram/document/DocumentControllerTest.java
@@ -6,17 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
@@ -24,9 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-public class DocumentControllerTest {
+public class DocumentControllerTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -43,10 +36,6 @@ public class DocumentControllerTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     @BeforeEach
     void setUp() throws Exception {

--- a/backend/src/test/java/team/projectpulse/ram/document/DocumentSectionControllerTest.java
+++ b/backend/src/test/java/team/projectpulse/ram/document/DocumentSectionControllerTest.java
@@ -6,18 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
@@ -25,9 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-public class DocumentSectionControllerTest {
+public class DocumentSectionControllerTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -44,10 +36,6 @@ public class DocumentSectionControllerTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     @BeforeEach
     void setUp() throws Exception {
@@ -95,7 +83,7 @@ public class DocumentSectionControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateDocumentSectionContent1() throws Exception {
         String json = """
                 {
@@ -165,7 +153,7 @@ public class DocumentSectionControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateDocumentSectionContent2() throws Exception {
         String json = """
                 {
@@ -214,7 +202,7 @@ public class DocumentSectionControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateDocumentSectionWithoutRequirementsArtifacts() throws Exception {
         String json = """
                 {
@@ -250,7 +238,7 @@ public class DocumentSectionControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateDocumentSectionWithoutRequirementsArtifacts_LockedByAnotherUser() throws Exception {
         String json = """
                 {
@@ -284,7 +272,7 @@ public class DocumentSectionControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateDocumentSectionWithoutRequirementsArtifacts_NotLocked() throws Exception {
         int version = fetchSectionVersion(1, 1, 2, this.studentJohnToken);
         String json = """
@@ -383,7 +371,7 @@ public class DocumentSectionControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void unlockDocumentSection() throws Exception {
         this.mockMvc.perform(delete(this.baseUrl + "/teams/1/documents/1/document-sections/1/lock").accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentJohnToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -400,7 +388,7 @@ public class DocumentSectionControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void unlockDocumentSection_Instructor() throws Exception {
         this.mockMvc.perform(delete(this.baseUrl + "/teams/1/documents/1/document-sections/1/lock").accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))

--- a/backend/src/test/java/team/projectpulse/ram/requirement/ArtifactLinkControllerTest.java
+++ b/backend/src/test/java/team/projectpulse/ram/requirement/ArtifactLinkControllerTest.java
@@ -6,18 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -26,9 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-public class ArtifactLinkControllerTest {
+public class ArtifactLinkControllerTest extends AbstractIntegrationTest {
     @Autowired
     MockMvc mockMvc;
 
@@ -44,10 +36,6 @@ public class ArtifactLinkControllerTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     @BeforeEach
     void setUp() throws Exception {
@@ -117,7 +105,6 @@ public class ArtifactLinkControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void addArtifactLink() throws Exception {
         String json = """
                 {
@@ -169,7 +156,6 @@ public class ArtifactLinkControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void deleteArtifactLink() throws Exception {
         this.mockMvc.perform(delete(this.baseUrl + "/teams/1/artifact-links/1").accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.studentEricToken))
                 .andExpect(jsonPath("$.flag").value(true))

--- a/backend/src/test/java/team/projectpulse/ram/requirement/RequirementArtifactControllerTest.java
+++ b/backend/src/test/java/team/projectpulse/ram/requirement/RequirementArtifactControllerTest.java
@@ -6,18 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
@@ -25,9 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-public class RequirementArtifactControllerTest {
+public class RequirementArtifactControllerTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -44,10 +36,6 @@ public class RequirementArtifactControllerTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     @BeforeEach
     void setUp() throws Exception {
@@ -83,7 +71,7 @@ public class RequirementArtifactControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+
     void findRequirementArtifactsByCriteria1() throws Exception {
         String json = """
                 {
@@ -101,7 +89,7 @@ public class RequirementArtifactControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+
     void findRequirementArtifactsByCriteria2() throws Exception {
         String json = """
                 {
@@ -116,7 +104,7 @@ public class RequirementArtifactControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+
     void findRequirementArtifactsByCriteria3() throws Exception {
         String json = """
                 {
@@ -201,7 +189,7 @@ public class RequirementArtifactControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateRequirementArtifact() throws Exception {
         String json = """
                 {

--- a/backend/src/test/java/team/projectpulse/ram/usecase/UseCaseControllerTest.java
+++ b/backend/src/test/java/team/projectpulse/ram/usecase/UseCaseControllerTest.java
@@ -6,18 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -26,9 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-class UseCaseControllerTest {
+class UseCaseControllerTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -45,10 +37,6 @@ class UseCaseControllerTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     @BeforeEach
     void setUp() throws Exception {
@@ -95,7 +83,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void addUseCase() throws Exception {
         // Given
         String json = """
@@ -233,7 +221,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void addUseCase_NotSameTeam() throws Exception {
         // Given
         String json = """
@@ -368,7 +356,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateUseCaseWithRewordedContent() throws Exception {
         lockUseCase(1, 3, this.studentEricToken);
         int version = fetchUseCaseVersion(1, 3, this.studentEricToken);
@@ -543,7 +531,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateUseCaseWithNewSteps() throws Exception {
         lockUseCase(1, 3, this.studentJohnToken);
         int version = fetchUseCaseVersion(1, 3, this.studentJohnToken);
@@ -742,7 +730,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateUseCaseWithDeletedSteps() throws Exception {
         lockUseCase(1, 3, this.adminBingyangToken);
         int version = fetchUseCaseVersion(1, 3, this.adminBingyangToken);
@@ -906,7 +894,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void updateUseCaseWithDeletedSteps_NotSameTeam() throws Exception {
         // Given
         String json = """
@@ -1073,7 +1061,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void lockUseCase() throws Exception {
         lockUseCase(1, 3, this.studentJohnToken);
 
@@ -1087,7 +1075,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void lockUseCase_AlreadyLocked() throws Exception {
         lockUseCase(1, 3, this.studentJohnToken);
 
@@ -1107,7 +1095,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void unlockUseCase() throws Exception {
         lockUseCase(1, 3, this.studentJohnToken);
 
@@ -1120,7 +1108,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void unlockUseCase_DifferentOwner() throws Exception {
         lockUseCase(1, 3, this.studentJohnToken);
 
@@ -1133,7 +1121,7 @@ class UseCaseControllerTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void unlockUseCase_Instructor() throws Exception {
         lockUseCase(1, 3, this.studentJohnToken);
 

--- a/backend/src/test/java/team/projectpulse/rubric/CriterionIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/rubric/CriterionIntegrationTest.java
@@ -1,26 +1,17 @@
 package team.projectpulse.rubric;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -35,13 +26,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Criterion API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-class CriterionIntegrationTest {
+class CriterionIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -56,10 +42,6 @@ class CriterionIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
 
     @BeforeEach
@@ -136,7 +118,6 @@ class CriterionIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void adminBingyangAddCriterion() throws Exception {
         // Given
         Map<String, String> criterionDto = new HashMap<>();
@@ -159,7 +140,6 @@ class CriterionIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void adminBingyangUpdateCriterion() throws Exception {
         // Given
         Map<String, String> criterionDto = new HashMap<>();
@@ -181,7 +161,6 @@ class CriterionIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void adminTimUpdateCriterion() throws Exception {
         // Given
         Map<String, String> criterionDto = new HashMap<>();

--- a/backend/src/test/java/team/projectpulse/rubric/RubricIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/rubric/RubricIntegrationTest.java
@@ -1,26 +1,17 @@
 package team.projectpulse.rubric;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -35,13 +26,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Rubric API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-class RubricIntegrationTest {
+class RubricIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -59,10 +45,6 @@ class RubricIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
 
     @BeforeEach
@@ -171,7 +153,6 @@ class RubricIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void addRubric() throws Exception {
         // Given
         Map<String, String> rubricDto = new HashMap<>();
@@ -190,7 +171,6 @@ class RubricIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void adminBingyangUpdateRubric() throws Exception {
         // Given
         Map<String, String> rubricDto = new HashMap<>();
@@ -209,7 +189,6 @@ class RubricIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void adminTimUpdateRubric() throws Exception {
         // Given
         Map<String, String> rubricDto = new HashMap<>();
@@ -229,7 +208,6 @@ class RubricIntegrationTest {
 //    }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void assignCriterionToRubric() throws Exception {
         this.mockMvc.perform(put(this.baseUrl + "/rubrics/1/criteria/7").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -254,7 +232,6 @@ class RubricIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void removeCriterionFromRubric() throws Exception {
         this.mockMvc.perform(delete(this.baseUrl + "/rubrics/1/criteria/6").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))

--- a/backend/src/test/java/team/projectpulse/section/SectionIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/section/SectionIntegrationTest.java
@@ -1,34 +1,22 @@
 package team.projectpulse.section;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MySQLContainer;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
 import java.util.List;
@@ -39,13 +27,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Section API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-class SectionIntegrationTest {
+class SectionIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -63,21 +46,6 @@ class SectionIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
-
-    @Container
-    static final GenericContainer<?> mailpit = new GenericContainer<>(DockerImageName.parse("axllent/mailpit"))
-            .withExposedPorts(1025, 8025);
-
-
-    @DynamicPropertySource
-    static void setMailpitProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.mail.host", mailpit::getHost);
-        registry.add("spring.mail.port", () -> mailpit.getMappedPort(1025));
-    }
 
     @BeforeEach
     void setUp() throws Exception {
@@ -222,7 +190,7 @@ class SectionIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+
     void instructorBillFindSectionById2() throws Exception {
         this.mockMvc.perform(get(this.baseUrl + "/sections/2").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.instructorBillToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -244,7 +212,7 @@ class SectionIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void adminBingyangAddSection() throws Exception {
         // Given
         Map<String, Object> sectionDto = new HashMap<>();
@@ -310,7 +278,7 @@ class SectionIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void adminBingyangUpdateSection() throws Exception {
         // Given
         Map<String, Object> sectionDto = new HashMap<>();
@@ -419,7 +387,7 @@ class SectionIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+
     void adminBingyangAssignInstructor() throws Exception {
         this.mockMvc.perform(put(this.baseUrl + "/sections/1/instructors/2").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))

--- a/backend/src/test/java/team/projectpulse/student/StudentIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/student/StudentIntegrationTest.java
@@ -1,31 +1,22 @@
 package team.projectpulse.student;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,13 +27,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Instructor API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-class StudentIntegrationTest {
+class StudentIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -62,10 +48,6 @@ class StudentIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
 
     @BeforeEach
@@ -166,7 +148,6 @@ class StudentIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testAddStudent() throws Exception {
         Map<String, String> studentDto = new HashMap<>();
         studentDto.put("username", "lucas");
@@ -245,7 +226,6 @@ class StudentIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void testStudentJohnUpdatesOwnInfo() throws Exception {
         Map<String, Object> studentDto = new HashMap<>();
         studentDto.put("username", "john");

--- a/backend/src/test/java/team/projectpulse/system/WebConfigSpaForwardingTest.java
+++ b/backend/src/test/java/team/projectpulse/system/WebConfigSpaForwardingTest.java
@@ -5,11 +5,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.SharedContainers;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -17,15 +18,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
-@Testcontainers
+@ActiveProfiles("dev")
 class WebConfigSpaForwardingTest {
 
     @Autowired
     MockMvc mockMvc;
 
-    @Container
     @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
+    static final MySQLContainer<?> mysql = SharedContainers.MYSQL;
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.mail.host", SharedContainers.MAILPIT::getHost);
+        registry.add("spring.mail.port", () -> SharedContainers.MAILPIT.getMappedPort(1025));
+    }
 
     @Test
     void shouldForwardThreeSegmentSpaRouteToIndexHtml() throws Exception {

--- a/backend/src/test/java/team/projectpulse/team/TeamIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/team/TeamIntegrationTest.java
@@ -1,26 +1,17 @@
 package team.projectpulse.team;
 
 import tools.jackson.databind.json.JsonMapper;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import team.projectpulse.AbstractIntegrationTest;
 import team.projectpulse.system.StatusCode;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -35,13 +26,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for Team API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-class TeamIntegrationTest {
+class TeamIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -59,10 +45,6 @@ class TeamIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
 
     @BeforeEach
@@ -183,7 +165,6 @@ class TeamIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void adminBingyangAddTeam() throws Exception {
         // Given
         Map<String, Object> teamDto = new HashMap<>();
@@ -225,7 +206,6 @@ class TeamIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void adminBingyangUpdateTeam() throws Exception {
         // Given
         Map<String, Object> teamDto = new HashMap<>();
@@ -290,7 +270,6 @@ class TeamIntegrationTest {
 //    }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void assignStudentToTeam() throws Exception {
         this.mockMvc.perform(put(this.baseUrl + "/teams/1/students/14").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -307,7 +286,6 @@ class TeamIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void removeStudentFromTeam() throws Exception {
         this.mockMvc.perform(delete(this.baseUrl + "/teams/1/students/4").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))
@@ -316,7 +294,6 @@ class TeamIntegrationTest {
     }
 
     @Test
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void assignInstructorToTeam() throws Exception {
         this.mockMvc.perform(put(this.baseUrl + "/teams/3/instructors/2").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, this.adminBingyangToken))
                 .andExpect(jsonPath("$.flag").value(true))

--- a/backend/src/test/java/team/projectpulse/user/UserIntegrationTest.java
+++ b/backend/src/test/java/team/projectpulse/user/UserIntegrationTest.java
@@ -1,33 +1,20 @@
 package team.projectpulse.user;
 
+import team.projectpulse.AbstractIntegrationTest;
 import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 import team.projectpulse.system.StatusCode;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@SpringBootTest
-@Testcontainers
-@AutoConfigureMockMvc
 @DisplayName("Integration tests for User API endpoints")
-@Tag("integration")
-@ActiveProfiles(value = "dev")
-class UserIntegrationTest {
+class UserIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -37,10 +24,6 @@ class UserIntegrationTest {
 
     @Value("${api.endpoint.base-url}")
     String baseUrl;
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
 
     @Test
     void testCheckUserExists1() throws Exception {


### PR DESCRIPTION
## Summary
- Introduce `SharedContainers` — singleton MySQL + Mailpit containers started once per JVM, shared across all integration test classes
- Introduce `AbstractIntegrationTest` — base class with `@Transactional` (auto-rollback after each test), replacing 60 `@DirtiesContext` annotations across 14 files
- Migrate all 17 integration test classes to extend the base class, removing per-class container declarations and redundant annotations

## Impact
| Metric | Before | After |
|--------|--------|-------|
| MySQL containers started | ~17 | 1 |
| Spring contexts created | ~77 | 2 |
| `@DirtiesContext` reloads | 60 | 0 |
| **Test suite runtime** | **~25-30 min** | **~5 min** |

## Test plan
- [x] Full test suite passes: 294 tests, 0 failures, 0 errors
- [x] Verified runtime: 5:11 min

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)